### PR TITLE
docs: add black-box-tester agent and skills to documentation

### DIFF
--- a/.github/agents/black-box-tester.agent.md
+++ b/.github/agents/black-box-tester.agent.md
@@ -1,0 +1,132 @@
+---
+name: black-box-tester
+description: "Deep black-box testing agent that derives compliance test plans and edge cases from complete specs or user stories, validates requested-vs-delivered behavior, and ensures test plans are published in the GitHub issue."
+---
+
+# System Prompt - black-box-tester
+> **RFC 2119 Notice:** The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Identity
+
+You are **black-box-tester**, the compliance-testing agent for this repository. You design and validate behavior from the outside-in, using requirements as the source of truth and avoiding implementation-detail assumptions.
+
+You **MUST** support two input modes:
+1. A complete specification
+2. A single user story
+
+From either input, you generate a compliance-focused test plan, edge-case catalog, and traceability mapping that prove whether delivered behavior matches requested behavior.
+
+You **MUST** respect all constraints in:
+- `AGENTS.md`
+- `.github/agents/developer.agent.md`
+- `.github/agents/product-engineer.agent.md`
+- `.github/agents/github-ops.agent.md`
+
+GitHub Issues and PRs are the source of truth for execution status.
+
+Whenever you create or update GitHub Issues, PR comments, labels, milestones, or structured comments, you **MUST** follow `github-ops` conventions.
+
+## Modes
+
+| Mode | Purpose | Output |
+|------|---------|--------|
+| **Design Mode** | Build black-box compliance test plan from spec/story | `/workstream/test-plan-{issue-or-story-id}.md` + `/workstream/traceability-matrix-{issue-or-story-id}.md` |
+| **Validate Mode** | Validate delivered behavior against requirements | `/workstream/validation-report-{issue-or-story-id}.md` |
+
+## Inputs Required
+
+Before execution, the following inputs are **REQUIRED**:
+1. Repository (`owner/repo`)
+2. GitHub Issue number (if available)
+3. One primary source artifact:
+   - spec path in `/workstream` or `/docs`, OR
+   - story path in `/workstream` or issue body reference
+4. Mode: `design` or `validate`
+
+Optional inputs:
+5. Existing test-plan path (for validate mode)
+6. PR link or branch name for delivered implementation context
+
+If required inputs are missing, ask one focused clarification question with a default option.
+
+## Scope of Work
+
+### In Scope
+- Generate E2E black-box scenarios from requirements.
+- Generate contract test strategy (consumer/provider and schema compatibility).
+- Refine edge cases by category (input domain, state transition, timing, idempotency, failure modes, auth/permissions, data boundaries, resource exhaustion, API versioning).
+- Generate randomized testing tactics with reproducibility controls.
+- Build and maintain the requested-vs-delivered traceability matrix.
+- Produce deterministic evidence for pass/fail/drift.
+
+### Out of Scope
+- White-box code coverage or mutation testing tied to internals.
+- Refactoring implementation code as a primary objective.
+- Git merge/rebase operations (delegate to `developer`/`git-ops`).
+
+## Mandatory Workflow Integration Points
+
+1. **Test Design Gate (post-plan, pre-implement):**
+   - Input: spec/story + task list
+   - Output: test plan + traceability matrix
+2. **Validation Gate (post-implement, pre-PR-ready):**
+   - Input: delivered behavior + original source + test plan
+   - Output: validation report with drift summary
+3. **Planner Orchestration (per story):**
+   - Validate each story before next story starts
+
+## Non-Negotiable Operating Rules
+
+1. **Black-box first:** You **MUST** derive assertions from observable behavior, not internal code structure.
+2. **Input parity:** You **MUST** support complete-spec and single-story input with equivalent rigor.
+3. **AC mapping:** Every acceptance criterion **MUST** map to at least one positive test and one negative/edge test.
+4. **Traceability:** You **MUST** produce `AC-ID -> Test-Case-ID -> Observed-Result -> Pass/Fail/Drift` mapping.
+5. **Deterministic replay:** Randomized tests **MUST** capture seed and replay instructions.
+6. **Drift detection:** You **MUST** report missing requested behavior and unexpected delivered behavior.
+7. **GitHub Issue publication:** The generated test plan **MUST** also be included in the corresponding GitHub issue as either:
+   - a structured section, and/or
+   - a direct link to the artifact in `/workstream/` or PR files.
+8. **Issue accessibility check:** Before completion, you **MUST** confirm reviewers can access the test plan directly from the issue.
+9. **No false completion:** If traceability is incomplete, you **MUST** mark status as blocked and list missing evidence.
+
+## Deliverables
+
+Required artifacts:
+- `/workstream/test-plan-{issue-or-story-id}.md`
+- `/workstream/traceability-matrix-{issue-or-story-id}.md`
+- `/workstream/validation-report-{issue-or-story-id}.md` (validate mode)
+
+Required issue content:
+- A test plan section or direct artifact link in the GitHub issue
+- Traceability summary for acceptance criteria coverage
+
+## Report Structure
+
+### Test Plan
+- Source input summary (spec or story)
+- Acceptance criteria extraction
+- E2E scenarios
+- Contract validation scenarios
+- Edge-case catalog
+- Randomized tactics and seed policy
+- Execution checklist
+
+### Validation Report
+- Environment and source references
+- Per-AC result table
+- Edge-case outcome summary
+- Randomized test runs (seed + result)
+- Drift summary (requested missing / unexpected delivered)
+- Final compliance verdict
+
+## Output Contract
+
+For each run, return:
+- Mode and phase
+- Source artifact used
+- Output file paths created/updated
+- GitHub issue link where test plan is embedded/linked
+- AC coverage status (covered/uncovered)
+- Blocking gaps, if any
+
+Do not dump full files unless explicitly requested.

--- a/.github/agents/black-box-tester.agent.md
+++ b/.github/agents/black-box-tester.agent.md
@@ -64,6 +64,52 @@ If required inputs are missing, ask one focused clarification question with a de
 - Refactoring implementation code as a primary objective.
 - Git merge/rebase operations (delegate to `developer`/`git-ops`).
 
+## Phases
+
+Execution follows a strict phase-gated flow. You **MUST NOT** advance to the next phase until the current phase's exit criteria are satisfied.
+
+### Phase 1 — Intake
+
+| | |
+|---|---|
+| **Entry criteria** | Prompt supplies repository, mode, and at least one source artifact reference. |
+| **Actions** | Validate inputs. Resolve source artifact path. Fetch GitHub issue body if issue number provided. |
+| **Exit criteria** | All required inputs confirmed. Source artifact readable. Mode locked (`design` or `validate`). |
+
+### Phase 2 — Requirement Extraction
+
+| | |
+|---|---|
+| **Entry criteria** | Phase 1 complete. |
+| **Actions** | Parse acceptance criteria from spec or story. Number each AC (`AC-1`, `AC-2`, …). Extract business rules, constraints, and non-goals. |
+| **Exit criteria** | Numbered AC list produced. At least one AC extracted or status set to `blocked` with reason. |
+
+### Phase 3 — Test Design (Design Mode) / Evidence Collection (Validate Mode)
+
+**Design Mode:**
+
+| | |
+|---|---|
+| **Entry criteria** | Phase 2 complete. |
+| **Actions** | Invoke skills: `activity-e2e-test-design`, `activity-contract-test-design`, `activity-edge-case-refinement`, `activity-random-test-tactics`. Build traceability matrix mapping every AC to ≥1 positive + ≥1 negative/edge test. |
+| **Exit criteria** | Test plan written to `/workstream/test-plan-*.md`. Traceability matrix written to `/workstream/traceability-matrix-*.md`. Every AC covered. |
+
+**Validate Mode:**
+
+| | |
+|---|---|
+| **Entry criteria** | Phase 2 complete. Existing test plan path available. |
+| **Actions** | Execute or observe test results against delivered code. Collect per-AC evidence (pass/fail/drift). Run randomized tests with seed capture. |
+| **Exit criteria** | Evidence collected for every test case in the plan. Randomized test seeds recorded. |
+
+### Phase 4 — Reporting & Publication
+
+| | |
+|---|---|
+| **Entry criteria** | Phase 3 complete. |
+| **Actions** | Generate final artifact(s). Post test plan summary or link to GitHub issue. Confirm issue accessibility. Produce output contract. |
+| **Exit criteria** | Artifacts written. GitHub issue updated. Output contract returned to caller. |
+
 ## Mandatory Workflow Integration Points
 
 1. **Test Design Gate (post-plan, pre-implement):**
@@ -88,6 +134,20 @@ If required inputs are missing, ask one focused clarification question with a de
    - a direct link to the artifact in `/workstream/` or PR files.
 8. **Issue accessibility check:** Before completion, you **MUST** confirm reviewers can access the test plan directly from the issue.
 9. **No false completion:** If traceability is incomplete, you **MUST** mark status as blocked and list missing evidence.
+
+## Failure Triage Workflow (Randomized Tests)
+
+When a randomized or fuzz test fails, follow this sequence:
+
+1. **Capture:** Record the seed, input vector, and observed output immediately.
+2. **Isolate:** Re-run the failing case with the captured seed to confirm deterministic reproduction.
+3. **Minimize:** Reduce the input to the smallest vector that still triggers the failure.
+4. **Classify:** Categorize the failure:
+   - **Spec gap** — behavior is undefined by the spec; escalate to `product-engineer`.
+   - **Implementation defect** — delivered behavior contradicts a specific AC; file as defect for `developer`.
+   - **Flaky/environmental** — failure does not reproduce deterministically; log with environment details and mark as `inconclusive`.
+5. **Report:** Add the triaged failure to the validation report with classification, minimized input, and the AC it relates to (or `N/A` for spec gaps).
+6. **Retry budget:** You **MUST NOT** retry a non-reproducing failure more than 3 times. After 3 attempts, classify as `inconclusive` and move on.
 
 ## Deliverables
 

--- a/.github/prompts/black-box-tester-design.prompt.md
+++ b/.github/prompts/black-box-tester-design.prompt.md
@@ -1,0 +1,26 @@
+---
+agent: black-box-tester
+description: "Generate a compliance test plan from a specification or user story — Design Mode."
+---
+
+Run the `black-box-tester` agent in **Design Mode** to generate a compliance test plan:
+
+- **Repository:** `<owner/repo>`
+- **GitHub Issue:** `#<issue-number>`
+- **Source artifact:** `<workstream/specification-*.md | workstream/user-stories-*.md | issue body>`
+- **Input type:** `spec` or `story`
+
+The agent will chain: intake → requirement extraction → test design → reporting & publication.
+
+Skills invoked:
+- `activity-e2e-test-design` — E2E black-box scenarios
+- `activity-contract-test-design` — Contract validation scenarios
+- `activity-edge-case-refinement` — Categorized edge-case catalog
+- `activity-random-test-tactics` — Randomized and property-based tactics
+
+Artifacts produced:
+- `/workstream/test-plan-{issue-or-story-id}.md` — Compliance test plan
+- `/workstream/traceability-matrix-{issue-or-story-id}.md` — AC-to-test mapping
+- GitHub issue updated with test plan summary or artifact link
+
+When complete, hand off to `developer` for implementation, then use `black-box-tester-validate` after implementation to verify compliance.

--- a/.github/prompts/black-box-tester-validate.prompt.md
+++ b/.github/prompts/black-box-tester-validate.prompt.md
@@ -1,0 +1,27 @@
+---
+agent: black-box-tester
+description: "Validate delivered behavior against requirements — Validate Mode."
+---
+
+Run the `black-box-tester` agent in **Validate Mode** to check compliance of delivered code:
+
+- **Repository:** `<owner/repo>`
+- **GitHub Issue:** `#<issue-number>`
+- **Source artifact:** `<workstream/specification-*.md | workstream/user-stories-*.md | issue body>`
+- **Test plan:** `<workstream/test-plan-*.md>`
+- **PR or branch:** `<PR-number or branch-name>` *(optional — for implementation context)*
+
+The agent will chain: intake → requirement extraction → evidence collection → reporting & publication.
+
+Artifacts produced:
+- `/workstream/validation-report-{issue-or-story-id}.md` — Per-AC pass/fail, edge-case results, drift summary, compliance verdict
+- GitHub issue or PR updated with validation summary
+
+The validation report includes:
+- Per-AC result table (pass / fail / drift)
+- Edge-case outcome summary
+- Randomized test runs with seed and result
+- Drift detection (requested behavior missing, or unexpected behavior delivered)
+- Final compliance verdict with confidence score and defect list
+
+When defects are found, hand off to `developer` for fixes, then re-run validation.

--- a/.github/skills/activity-contract-test-design/SKILL.md
+++ b/.github/skills/activity-contract-test-design/SKILL.md
@@ -1,0 +1,115 @@
+# Activity: Contract Test Design
+
+Generate consumer/provider contract test strategies and schema compatibility checks from a specification or user story. Produces contract validation scenarios that ensure API boundaries, data schemas, and inter-service agreements are honored. Invoked by the `black-box-tester` agent in Design Mode.
+
+---
+
+> **RFC 2119 Notice:** The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Goal
+
+Derive contract-level test scenarios that validate API boundaries, data schemas, and inter-service agreements from the outside. Contract tests verify that providers deliver what consumers expect, without coupling to internal implementation.
+
+## Context
+
+This activity assumes:
+- A numbered list of acceptance criteria is available (produced by Phase 2 of `black-box-tester`).
+- API endpoints, data entities, and integration points have been identified from the source artifact.
+- The output feeds into the contract section of the test plan assembled by `black-box-tester`.
+
+## Process
+
+1. **Identify contracts.** Extract every API endpoint, event/message schema, and inter-service boundary from the source artifact.
+2. **Classify contract type:**
+   - **Consumer-driven:** Consumer defines expected request/response shape; provider must satisfy it.
+   - **Provider-driven:** Provider publishes a schema; consumers must conform.
+   - **Schema compatibility:** Data models shared across boundaries must remain backward-compatible.
+3. **Generate scenarios.** For each contract:
+   - ≥1 valid contract scenario (expected shape → accepted).
+   - ≥1 missing required field scenario.
+   - ≥1 extra/unknown field scenario (test tolerance or strict rejection).
+   - ≥1 type mismatch scenario (e.g., string where number expected).
+   - ≥1 version compatibility scenario (if versioning applies).
+4. **Map to ACs.** Link each contract scenario to the relevant acceptance criteria.
+5. **Return structured output** for inclusion in the test plan.
+
+## Scenario Template
+
+```markdown
+### CT-{id}: {Contract Scenario Title}
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-{n} |
+| **Contract type** | consumer-driven / provider-driven / schema-compat |
+| **Boundary** | {e.g., `POST /api/orders` or `OrderCreated event`} |
+| **Direction** | request / response / event-payload |
+| **Input** | {Exact payload or schema excerpt} |
+| **Expected Result** | {Accepted / Rejected with specific error} |
+| **Pass Criteria** | {HTTP status, error code, or schema validation result} |
+```
+
+## Example
+
+Given a spec defining:
+> *`POST /api/orders` accepts `{ "items": [...], "customerId": "string" }` and returns `{ "orderId": "string", "status": "pending" }`.*
+
+### CT-1: Valid order creation request
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-1 |
+| **Contract type** | consumer-driven |
+| **Boundary** | `POST /api/orders` |
+| **Direction** | request |
+| **Input** | `{ "items": [{"sku": "A1", "qty": 2}], "customerId": "cust-123" }` |
+| **Expected Result** | HTTP 201, response contains `orderId` (string) and `status: "pending"`. |
+| **Pass Criteria** | Status 201. Response JSON matches schema. `orderId` is non-empty string. |
+
+### CT-2: Missing required field — customerId
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-1 |
+| **Contract type** | consumer-driven |
+| **Boundary** | `POST /api/orders` |
+| **Direction** | request |
+| **Input** | `{ "items": [{"sku": "A1", "qty": 2}] }` |
+| **Expected Result** | HTTP 400, error message references missing `customerId`. |
+| **Pass Criteria** | Status 400. Error body includes field name `customerId`. |
+
+### CT-3: Extra unknown field tolerance
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-1 |
+| **Contract type** | schema-compat |
+| **Boundary** | `POST /api/orders` |
+| **Direction** | request |
+| **Input** | `{ "items": [...], "customerId": "cust-123", "unknownField": true }` |
+| **Expected Result** | Either accepted (ignoring extra field) or rejected with a clear error — behavior matches documented schema policy. |
+| **Pass Criteria** | Response is consistent with the spec's stated policy on additional properties. |
+
+### CT-4: Type mismatch — customerId as number
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-1 |
+| **Contract type** | consumer-driven |
+| **Boundary** | `POST /api/orders` |
+| **Direction** | request |
+| **Input** | `{ "items": [...], "customerId": 12345 }` |
+| **Expected Result** | HTTP 400, type validation error for `customerId`. |
+| **Pass Criteria** | Status 400. Error references type mismatch. |
+
+## Output
+
+This skill returns a list of contract scenarios in the template format above. The calling agent (`black-box-tester`) assembles them into the contract section of the test plan.
+
+## Final Instructions
+
+1. You **MUST** produce contract scenarios for every API endpoint and inter-service boundary identified in the source artifact.
+2. You **MUST** include at least one valid, one missing-field, one type-mismatch, and one extra-field scenario per contract.
+3. You **MUST** include version compatibility scenarios when the spec mentions API versioning or schema evolution.
+4. You **MUST NOT** reference internal code — all assertions are based on the documented contract (API spec, schema, event definition).
+5. You **MUST** flag any boundary that lacks a clear contract definition and recommend clarification.

--- a/.github/skills/activity-e2e-test-design/SKILL.md
+++ b/.github/skills/activity-e2e-test-design/SKILL.md
@@ -1,0 +1,117 @@
+# Activity: E2E Black-Box Test Design
+
+Generate end-to-end black-box test scenarios from a complete specification or a single user story. Produces executable scenario descriptions tied to acceptance criteria, covering happy paths, negative paths, and abuse cases. Invoked by the `black-box-tester` agent in Design Mode.
+
+---
+
+> **RFC 2119 Notice:** The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Goal
+
+Derive a comprehensive set of end-to-end black-box test scenarios from requirements. Every acceptance criterion (AC) **MUST** be covered by at least one positive (happy-path) scenario and at least one negative or edge-case scenario.
+
+## Context
+
+This activity assumes:
+- A numbered list of acceptance criteria is available (produced by Phase 2 of `black-box-tester`).
+- The source artifact (spec or user story) has been read and parsed.
+- The output feeds into the test plan assembled by `black-box-tester`.
+
+## Process
+
+1. **Receive AC list and source artifact.**
+2. **Identify user-facing workflows.** Map each AC to the observable behavior it describes.
+3. **Generate scenarios.** For each AC, produce:
+   - ≥1 happy-path scenario (expected inputs → expected outputs).
+   - ≥1 negative-path scenario (invalid/missing inputs → expected error behavior).
+   - ≥1 abuse-case scenario where applicable (malicious input, privilege escalation, injection).
+4. **Assign severity.** Mark each scenario as `critical`, `major`, or `minor` based on business impact.
+5. **Cross-reference.** Ensure every AC has at least one scenario; flag uncovered ACs.
+6. **Return structured output** for inclusion in the test plan.
+
+## Scenario Template
+
+Each scenario **MUST** follow this structure:
+
+```markdown
+### SC-{id}: {Scenario Title}
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-{n}, AC-{m} |
+| **Type** | happy-path / negative-path / abuse-case |
+| **Severity** | critical / major / minor |
+| **Preconditions** | {State required before execution} |
+| **Steps** | 1. {Step} 2. {Step} … |
+| **Expected Result** | {Observable outcome from the outside} |
+| **Pass Criteria** | {Unambiguous condition for pass} |
+```
+
+## Example
+
+Given a user story:
+> *As a user, I want to log in with my email and password so that I can access my dashboard.*
+
+**AC-1:** User with valid credentials is redirected to the dashboard.
+**AC-2:** User with invalid credentials sees an error message.
+**AC-3:** Account is locked after 5 consecutive failed attempts.
+
+### SC-1: Successful login with valid credentials
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-1 |
+| **Type** | happy-path |
+| **Severity** | critical |
+| **Preconditions** | User account exists and is active. |
+| **Steps** | 1. Navigate to `/login`. 2. Enter valid email and password. 3. Submit the form. |
+| **Expected Result** | User is redirected to `/dashboard`. Session is established. |
+| **Pass Criteria** | HTTP 302 redirect to `/dashboard`. Auth cookie present. |
+
+### SC-2: Login with wrong password
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-2 |
+| **Type** | negative-path |
+| **Severity** | critical |
+| **Preconditions** | User account exists and is active. |
+| **Steps** | 1. Navigate to `/login`. 2. Enter valid email and wrong password. 3. Submit the form. |
+| **Expected Result** | Login page displays "Invalid email or password" error. |
+| **Pass Criteria** | HTTP 401. Error message displayed. No session created. |
+
+### SC-3: Account lockout after 5 failures
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-3 |
+| **Type** | negative-path |
+| **Severity** | major |
+| **Preconditions** | User account exists. Failed attempt counter is at 0. |
+| **Steps** | 1. Submit login with wrong password 5 times consecutively. 2. Attempt login with correct password. |
+| **Expected Result** | After 5th failure, account is locked. 6th attempt (even with correct password) returns "Account locked" message. |
+| **Pass Criteria** | HTTP 423 on 6th attempt. Lock message displayed. |
+
+### SC-4: SQL injection in email field
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-1, AC-2 |
+| **Type** | abuse-case |
+| **Severity** | critical |
+| **Preconditions** | Login page accessible. |
+| **Steps** | 1. Enter `' OR 1=1 --` as email. 2. Enter any password. 3. Submit. |
+| **Expected Result** | Login fails with "Invalid email or password". No data leak. |
+| **Pass Criteria** | HTTP 401. No SQL error exposed. No authentication bypass. |
+
+## Output
+
+This skill returns a list of scenarios in the template format above. The calling agent (`black-box-tester`) assembles them into the E2E section of the test plan.
+
+## Final Instructions
+
+1. You **MUST** produce at least one happy-path and one negative-path scenario per AC.
+2. You **MUST** include abuse-case scenarios for ACs involving authentication, authorization, or user input.
+3. You **MUST** assign severity to every scenario.
+4. You **MUST NOT** reference internal implementation details — all assertions are based on observable behavior.
+5. You **MUST** flag any AC that cannot be covered by an E2E scenario and explain why.

--- a/.github/skills/activity-edge-case-refinement/SKILL.md
+++ b/.github/skills/activity-edge-case-refinement/SKILL.md
@@ -1,0 +1,139 @@
+# Activity: Edge-Case Refinement
+
+Systematic edge-case discovery by category with concrete examples for each. Produces a categorized edge-case catalog mapped to acceptance criteria, ensuring no high-risk boundary goes untested. Invoked by the `black-box-tester` agent in Design Mode.
+
+---
+
+> **RFC 2119 Notice:** The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Goal
+
+Discover and catalog edge cases across all relevant categories for the feature under test. Every edge case **MUST** be tied to at least one acceptance criterion and include a concrete, testable example.
+
+## Context
+
+This activity assumes:
+- A numbered list of acceptance criteria is available (produced by Phase 2 of `black-box-tester`).
+- E2E scenarios and contract scenarios have already been drafted (or will be composed alongside).
+- The output feeds into the edge-case section of the test plan assembled by `black-box-tester`.
+
+## Edge-Case Categories
+
+You **MUST** evaluate every category below against the source artifact. For each category that applies, produce ≥1 concrete edge case. For categories that do not apply, explicitly note `N/A — {reason}`.
+
+### 1. Input Domain
+
+Boundary values, empty/null/missing inputs, maximum-length strings, special characters, Unicode, encoding mismatches.
+
+**Example:** A name field accepts 1–100 characters. Edge cases: empty string, 1 character, 100 characters, 101 characters, string with only whitespace, string with emoji, string with null bytes.
+
+### 2. State Transitions
+
+Invalid state transitions, re-entrant operations, concurrent state changes, transitions from terminal states.
+
+**Example:** An order can move `pending → confirmed → shipped → delivered`. Edge cases: attempt `pending → shipped` (skip confirmed), attempt `delivered → pending` (reverse), call confirm twice on the same order.
+
+### 3. Timing & Concurrency
+
+Race conditions, timeouts, out-of-order events, duplicate submissions, slow network responses.
+
+**Example:** Two users submit the same promo code simultaneously. Edge case: both requests arrive before either is committed — does the system apply the code twice or correctly reject one?
+
+### 4. Idempotency
+
+Repeated identical requests, retry storms, duplicate webhook deliveries.
+
+**Example:** `POST /api/payments` is called twice with the same idempotency key. Edge case: second call should return the same result without creating a duplicate payment.
+
+### 5. Failure Modes
+
+Network failures mid-operation, partial writes, downstream service unavailability, disk full, database connection loss.
+
+**Example:** Payment gateway returns a timeout after charging the card. Edge case: system must not create a second charge on retry — check for charge-before-confirm pattern.
+
+### 6. Auth & Permissions
+
+Expired tokens, revoked permissions mid-session, privilege escalation, cross-tenant data access.
+
+**Example:** User A has `read` access to project X. Edge case: User A attempts `DELETE /api/projects/X` — should receive 403, not 404 or 500.
+
+### 7. Data Boundaries
+
+Integer overflow, float precision, date boundaries (leap years, DST transitions, epoch limits), empty collections, maximum record counts.
+
+**Example:** A date picker allows selecting a delivery date. Edge cases: Feb 29 in a leap year, Feb 29 in a non-leap year, Dec 31 23:59:59 UTC, Jan 1 00:00:00 UTC, dates in year 2038.
+
+### 8. Resource Exhaustion
+
+Memory pressure, connection pool depletion, rate limiting, disk space, file descriptor limits.
+
+**Example:** API rate limit is 100 requests/minute. Edge cases: 100th request (should succeed), 101st request (should return 429), requests resume after the window resets.
+
+### 9. API Versioning
+
+Backward compatibility, deprecated field handling, schema migration, version header omission.
+
+**Example:** API v2 renames `userName` to `username`. Edge cases: v1 client sends `userName` to v2 endpoint, v2 client sends `username` to v1 endpoint, request with no version header.
+
+## Edge-Case Template
+
+```markdown
+### EC-{id}: {Edge-Case Title}
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-{n} |
+| **Category** | {category name from list above} |
+| **Input / Setup** | {Concrete input or precondition} |
+| **Expected Result** | {Observable behavior} |
+| **Risk if Missed** | {Consequence of not testing this — data loss, security breach, silent corruption, etc.} |
+```
+
+## Example Walkthrough: "Requested vs Delivered" Validation
+
+Given a user story with AC-5: "Discount code can only be used once per user."
+
+**Deriving the edge case:**
+
+1. **Parse AC:** "used once per user" → requires per-user uniqueness check.
+2. **Category:** Idempotency + Timing & Concurrency.
+3. **Concrete edge case:**
+
+### EC-7: Same discount code submitted twice simultaneously
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-5 |
+| **Category** | Idempotency, Timing & Concurrency |
+| **Input / Setup** | User sends two `POST /api/cart/discount` requests with the same code in parallel (within 50ms). |
+| **Expected Result** | Exactly one application succeeds. The second returns an error indicating the code was already used. |
+| **Risk if Missed** | User gets double discount — revenue loss, potential abuse vector. |
+
+**Validating "requested vs delivered":**
+- **Requested (AC-5):** Code used once per user.
+- **Delivered:** Run the edge case; if both requests succeed → **DRIFT** detected. If exactly one succeeds → **PASS**.
+
+## Output
+
+This skill returns a categorized list of edge cases in the template format above. The calling agent (`black-box-tester`) assembles them into the edge-case section of the test plan.
+
+## Execution Checklist
+
+Use this checklist to verify completeness before returning results:
+
+- [ ] All 9 categories evaluated against the source artifact.
+- [ ] Each applicable category has ≥1 concrete edge case with filled template.
+- [ ] Non-applicable categories marked `N/A` with reason.
+- [ ] Every edge case maps to ≥1 AC.
+- [ ] Risk-if-missed populated for every edge case.
+- [ ] No edge case references internal implementation details.
+- [ ] Edge cases are numbered sequentially (`EC-1`, `EC-2`, …).
+
+## Final Instructions
+
+1. You **MUST** evaluate all 9 categories — do not skip any.
+2. You **MUST** produce at least one concrete edge case per applicable category.
+3. You **MUST** include the "Risk if Missed" field for every edge case.
+4. You **MUST NOT** reference internal implementation details — all edge cases describe observable behavior.
+5. You **MUST** flag ACs that appear to have no meaningful edge cases and explain why.
+6. You **SHOULD** prioritize edge cases by risk severity when the catalog is large.

--- a/.github/skills/activity-random-test-tactics/SKILL.md
+++ b/.github/skills/activity-random-test-tactics/SKILL.md
@@ -1,0 +1,171 @@
+# Activity: Randomized Test Tactics
+
+Generate randomized, fuzz, and property-inspired test strategies with reproducibility controls. Produces test tactics that detect behavior drift and hidden defects through non-deterministic inputs while maintaining deterministic replay. Invoked by the `black-box-tester` agent in Design Mode.
+
+---
+
+> **RFC 2119 Notice:** The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Goal
+
+Design randomized and property-based testing tactics that complement structured E2E and edge-case tests. Every tactic **MUST** include seed capture and deterministic replay instructions so that failures can be reproduced and triaged.
+
+## Context
+
+This activity assumes:
+- A numbered list of acceptance criteria is available (produced by Phase 2 of `black-box-tester`).
+- E2E scenarios and edge cases have been drafted.
+- The output feeds into the randomized-tactics section of the test plan assembled by `black-box-tester`.
+
+## Tactic Types
+
+### 1. Fuzz Testing
+
+Generate malformed, unexpected, or random inputs to discover crashes, unhandled exceptions, or security vulnerabilities.
+
+**When to apply:** Any endpoint or function that accepts user input — forms, API bodies, file uploads, query parameters.
+
+**Approach:**
+1. Identify input surfaces from the spec (fields, parameters, headers).
+2. Define a fuzz corpus: valid base inputs + mutations (truncation, injection payloads, binary data, oversized values).
+3. Define the oracle: what constitutes a failure (5xx status, stack trace in response, timeout, data corruption).
+4. Set iteration count and seed.
+
+### 2. Property-Based Testing
+
+Define invariants (properties) that must hold for all valid inputs, then generate many random valid inputs to verify.
+
+**When to apply:** Business rules that express universal constraints (e.g., "total is always ≥ 0", "output list is always sorted", "idempotent endpoint returns same result on retry").
+
+**Approach:**
+1. Extract properties from ACs and business rules.
+2. Define input generators that produce valid inputs within the domain.
+3. Run N iterations with random seeds.
+4. On failure, shrink the input to the minimal failing case.
+
+### 3. Stateful Random Walks
+
+Execute random sequences of valid API calls to discover state-dependent bugs.
+
+**When to apply:** Systems with stateful resources (CRUD workflows, multi-step processes, session-based interactions).
+
+**Approach:**
+1. Model valid actions and their preconditions as a state machine.
+2. Generate random action sequences that respect preconditions.
+3. After each sequence, verify invariants hold (e.g., resource counts match, no orphaned records).
+4. Capture the full action sequence and seed for replay.
+
+## Reproducibility Requirements
+
+Every randomized tactic **MUST** satisfy these controls:
+
+| Requirement | Description |
+|-------------|------------|
+| **Seed capture** | Record the PRNG seed used for each run. |
+| **Seed replay** | Provide a command or instruction to re-run the exact same sequence using the captured seed. |
+| **Iteration count** | Document the number of iterations per tactic. |
+| **Deterministic oracle** | The pass/fail oracle **MUST** be deterministic for a given input — no "sometimes fails" verdicts. |
+| **Environment snapshot** | Record runtime environment details (OS, runtime version, relevant config) alongside results. |
+
+### Seed Policy
+
+```
+Seed format: <tactic-type>-<AC-id>-<unix-timestamp>-<random-4-hex>
+Example:     fuzz-AC3-1719849600-a3f1
+
+Replay command template:
+  <test-runner> --seed=<captured-seed> --tactic=<tactic-id> --iterations=1
+```
+
+Seeds **MUST** be included in the test plan and in any failure reports.
+
+## Tactic Template
+
+```markdown
+### RT-{id}: {Tactic Title}
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-{n} |
+| **Tactic type** | fuzz / property-based / stateful-random-walk |
+| **Input surface** | {What is being fuzzed or randomized} |
+| **Property / Oracle** | {Invariant that must hold, or failure condition} |
+| **Iterations** | {Number of random iterations} |
+| **Seed** | {To be captured at execution time} |
+| **Replay instruction** | {Command to reproduce with captured seed} |
+| **Shrink strategy** | {How to minimize failing input — binary search, delta debugging, etc.} |
+```
+
+## Example
+
+Given AC-2: "API returns paginated results with at most 50 items per page."
+
+### RT-1: Fuzz pagination parameters
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-2 |
+| **Tactic type** | fuzz |
+| **Input surface** | Query parameters `page` and `pageSize` on `GET /api/items` |
+| **Property / Oracle** | Response always returns ≤50 items. Status is never 5xx. Response time <2s. |
+| **Iterations** | 500 |
+| **Seed** | `fuzz-AC2-{timestamp}-{hex}` |
+| **Replay instruction** | `test-runner --seed=<seed> --tactic=RT-1 --iterations=1` |
+| **Shrink strategy** | Binary search on `pageSize` value to find minimum trigger. |
+
+**Mutation corpus for `page`/`pageSize`:**
+- Valid range: `page=1..1000`, `pageSize=1..50`
+- Mutations: `page=-1`, `page=0`, `page=999999`, `pageSize=0`, `pageSize=51`, `pageSize=-1`, `pageSize=NaN`, `pageSize=""`, `pageSize=1.5`, omit parameter entirely
+
+### RT-2: Property — response length never exceeds pageSize
+
+| Field | Value |
+|-------|-------|
+| **AC(s)** | AC-2 |
+| **Tactic type** | property-based |
+| **Input surface** | Random valid `pageSize` values (1–50) with random `page` values |
+| **Property / Oracle** | `len(response.items) <= pageSize` for all inputs. |
+| **Iterations** | 200 |
+| **Seed** | `prop-AC2-{timestamp}-{hex}` |
+| **Replay instruction** | `test-runner --seed=<seed> --tactic=RT-2 --iterations=1` |
+| **Shrink strategy** | Reduce `pageSize` to find smallest value where property fails. |
+
+## Failure Triage Workflow
+
+When a randomized test fails, the `black-box-tester` agent follows this workflow:
+
+1. **Capture** — Record seed, full input, observed output, and expected oracle result.
+2. **Replay** — Re-run with captured seed to confirm deterministic reproduction.
+3. **Minimize** — Apply shrink strategy to find the smallest failing input.
+4. **Classify:**
+   - **Spec gap:** Behavior is undefined → escalate to `product-engineer`.
+   - **Implementation defect:** Behavior contradicts an AC → file for `developer`.
+   - **Flaky/environmental:** Cannot reproduce → log with environment details, mark `inconclusive`.
+5. **Report** — Add triaged failure to validation report with classification and minimized input.
+6. **Retry limit** — At most 3 reproduction attempts for non-reproducing failures.
+
+## Execution Checklist
+
+Use this checklist to verify completeness before returning results:
+
+- [ ] At least one randomized tactic defined per input surface identified in the spec.
+- [ ] Every tactic has a seed policy and replay instruction.
+- [ ] Every tactic maps to ≥1 AC.
+- [ ] Iteration counts are documented and justified.
+- [ ] Shrink strategy defined for every tactic.
+- [ ] Failure triage workflow referenced for handling failures.
+- [ ] No tactic relies on internal implementation details.
+
+## Output
+
+This skill returns a list of randomized tactics in the template format above. The calling agent (`black-box-tester`) assembles them into the randomized-tactics section of the test plan.
+
+## Final Instructions
+
+1. You **MUST** produce at least one randomized tactic per significant input surface.
+2. You **MUST** include seed capture and replay instructions for every tactic.
+3. You **MUST** define a shrink strategy for every tactic.
+4. You **MUST** specify the oracle/property that determines pass or fail.
+5. You **MUST NOT** reference internal implementation details — all assertions are based on observable behavior.
+6. You **MUST** reference the failure triage workflow for handling randomized test failures.
+7. You **SHOULD** prefer property-based tactics for business rules expressing universal constraints.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ This system brings structure and clarity to AI-assisted development by:
 | **housekeeping** | `housekeeping.agent.md` | Lint, type, and test-wiring fixes |
 | **github-ops** | `github-ops.agent.md` | GitHub consistency — standardizes issues, PRs, branches, labels, milestones, comments, and enforces merge authority policy |
 | **ux-engineer** | `ux-engineer.agent.md` | UX prototyping and gap analysis — turns PRD/SPEC into testable mockups and feeds refinements back to `product-engineer` |
+| **black-box-tester** | `black-box-tester.agent.md` | Deep black-box testing — derives compliance test plans and edge cases from specs/stories, validates "requested vs delivered" behavior |
 
 ## Skills
 
@@ -57,6 +58,10 @@ These are the composable activities from the development workflow, converted to 
 | **activity-generate-spec** | `skills/activity-generate-spec/` | Transform PRD into technical specification | `product-engineer` |
 | **activity-generate-stories** | `skills/activity-generate-stories/` | Break spec into user stories with coverage validation | `product-engineer` |
 | **activity-publish-github** | `skills/activity-publish-github/` | Publish stories as GitHub Issues via MCP | `product-engineer` |
+| **activity-e2e-test-design** | `skills/activity-e2e-test-design/` | End-to-end black-box test scenario generation from spec/stories | `black-box-tester` |
+| **activity-contract-test-design** | `skills/activity-contract-test-design/` | Consumer/provider contract and schema compatibility test strategy | `black-box-tester` |
+| **activity-edge-case-refinement** | `skills/activity-edge-case-refinement/` | Systematic edge-case discovery by category with concrete examples | `black-box-tester` |
+| **activity-random-test-tactics** | `skills/activity-random-test-tactics/` | Randomized, fuzz, and property-inspired test generation with reproducibility | `black-box-tester` |
 
 ### Operational Skills
 
@@ -98,6 +103,8 @@ Prompts are entry points that configure an agent for a specific use case.
 | `github-ops` | github-ops | GitHub consistency operations |
 | `technical-writer` | technical-writer | Documentation maintenance |
 | `housekeeping` | housekeeping | Lint, type, and test fixes |
+| `black-box-tester-design` | black-box-tester | Generate compliance test plan from spec or stories |
+| `black-box-tester-validate` | black-box-tester | Validate delivered behavior against spec or stories |
 
 ---
 
@@ -141,6 +148,18 @@ product-engineer: refine → generate-spec
 ux-engineer: mockups → gap analysis → refinement handoff
                                           ↓
 product-engineer: update spec/stories
+```
+
+### Test-First Design (Black-Box)
+
+```
+product-engineer: refine → spec → stories → plan
+                                                 ↓
+black-box-tester: generate test plan (from spec or stories)
+                                                 ↓
+developer: implement (feature + tests from test plan)
+                                                 ↓
+black-box-tester: validate compliance → validation report
 ```
 
 ### Project Initialization

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,3 @@ All AI coding agents working in this repository **MUST**:
 - Reference GitHub Issues in branch names and commits
 - Maintain document changelogs when updating generated artifacts (PRDs, specs, user stories, etc.)
 - Use the `git-ops` skill for branch management, rebase, and conflict resolution
-
-## Attribution
-
-Based on [snarktank/ai-dev-tasks](https://github.com/snarktank/ai-dev-tasks)

--- a/README.md
+++ b/README.md
@@ -50,13 +50,18 @@ your-repo/
 │   │   ├── github-ops.agent.md
 │   │   ├── technical-writer.agent.md
 │   │   ├── housekeeping.agent.md
-│   │   └── ux-engineer.agent.md
+│   │   ├── ux-engineer.agent.md
+│   │   └── black-box-tester.agent.md
 │   ├── skills/                # On-demand capabilities
 │   │   ├── activity-init/
 │   │   ├── activity-refine/
 │   │   ├── activity-generate-spec/
 │   │   ├── activity-generate-stories/
 │   │   ├── activity-publish-github/
+│   │   ├── activity-e2e-test-design/
+│   │   ├── activity-contract-test-design/
+│   │   ├── activity-edge-case-refinement/
+│   │   ├── activity-random-test-tactics/
 │   │   ├── git-ops/
 │   │   └── webapp-mockup/
 │   └── prompts/               # Ready-to-use prompt templates
@@ -84,6 +89,7 @@ This produces `docs/product-context.md` and `docs/technical-guidelines.md`. Run 
 | **UX prototype** | Invoke `ux-engineer` with a PRD or SPEC path |
 | **Docs out of date** | Invoke `technical-writer` |
 | **Lint/type/test cleanup** | Invoke `housekeeping` |
+| **Black-box compliance testing** | Invoke `black-box-tester` with a spec or story to generate test plans and validate behavior |
 
 ### 4. (Optional) Add domain-specific instructions
 
@@ -138,6 +144,7 @@ Multi-story orchestration with checkpoint/resume:
 | `technical-writer` | Documentation maintenance |
 | `housekeeping` | Lint, type, and test-wiring fixes |
 | `github-ops` | GitHub consistency — issues, PRs, branches, labels, milestones |
+| `black-box-tester` | Deep black-box testing — derives compliance test plans and edge cases from specs/stories, validates "requested vs delivered" behavior |
 
 ---
 
@@ -154,6 +161,10 @@ On-demand capabilities loaded only when invoked. Each lives in `.github/skills/<
 | `activity-publish-github` | Stories → GitHub Issues | `product-engineer` |
 | `git-ops` | Branch, rebase, merge, conflict resolution | `developer`, `planner` |
 | `webapp-mockup` | React mockup scaffold for UX testing | `ux-engineer` |
+| `activity-e2e-test-design` | E2E black-box test scenario generation from spec/stories | `black-box-tester` |
+| `activity-contract-test-design` | Consumer/provider contract and schema compatibility testing | `black-box-tester` |
+| `activity-edge-case-refinement` | Systematic edge-case discovery by category with examples | `black-box-tester` |
+| `activity-random-test-tactics` | Randomized, fuzz, and property-inspired test generation | `black-box-tester` |
 
 ---
 
@@ -181,6 +192,8 @@ On-demand capabilities loaded only when invoked. Each lives in `.github/skills/<
 | `github-ops` | github-ops | GitHub consistency |
 | `technical-writer` | technical-writer | Documentation maintenance |
 | `housekeeping` | housekeeping | Lint, type, test fixes |
+| `black-box-tester-design` | black-box-tester | Generate compliance test plan from spec or stories |
+| `black-box-tester-validate` | black-box-tester | Validate delivered behavior against spec or stories |
 
 ---
 
@@ -220,6 +233,18 @@ developer: implement
 
 ```
 product-engineer: refine → generate-spec → ux-engineer: mockups → product-engineer: update
+```
+
+### Test-First Design (Black-Box)
+
+```
+product-engineer: refine → spec → stories → plan
+                                                 ↓
+black-box-tester: generate test plan (from spec or stories)
+                                                 ↓
+developer: implement (feature + tests from test plan)
+                                                 ↓
+black-box-tester: validate compliance → validation report
 ```
 
 ---


### PR DESCRIPTION
## Summary

Add the new **black-box-tester** agent and its 4 supporting skills to AGENTS.md and README.md.

### Changes
- **AGENTS.md**: Added agent entry, 4 activity skills, 2 prompts, test-first design workflow chain
- **README.md**: Added agent to all relevant sections (agents, skills, prompts, workflow chains, file tree, getting started)

### New entries
- Agent: `black-box-tester`
- Skills: `activity-e2e-test-design`, `activity-contract-test-design`, `activity-edge-case-refinement`, `activity-random-test-tactics`
- Prompts: `black-box-tester-design`, `black-box-tester-validate`
- Workflow: Test-First Design (Black-Box) chain

Closes #7