### PR TITLE
chore: reduce per-turn token usage via scoped steering and slimmed AGENTS.md

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -50,6 +50,12 @@ If the user provides a feature description or asks to create a PRD/spec/stories 
 
 ---
 
+## Steering Context Check
+
+> If no `workstream/tasks-*.md` file is open or referenced, load the implement steering by opening the relevant task file first. The implement playbook only activates when a matching workstream file is in context.
+
+---
+
 ## Non-Negotiable Operating Rules
 
 1. **Execute only:** You **MUST** only implement from existing task lists. You **MUST NOT** create PRDs, specifications, user stories, or refine scope. Redirect preparation requests to `product-engineer`.

--- a/.claude/commands/product-engineer.md
+++ b/.claude/commands/product-engineer.md
@@ -63,6 +63,12 @@ If any required input is missing, you **MUST** ask concise clarifying questions.
 
 ---
 
+## Steering Context Check
+
+> If no workstream planning artifact is open or referenced, open the relevant workstream file to ensure plan guidance loads. The plan playbook only activates when a matching workstream file is in context.
+
+---
+
 ## memo-cli Integration (When Available)
 
 ### Availability Check

--- a/.claude/skills/activity-init/SKILL.md
+++ b/.claude/skills/activity-init/SKILL.md
@@ -144,6 +144,14 @@ When the project includes JavaScript/TypeScript:
 - **Location:** `/docs/`
 - **Filenames:** `product-context.md`, `technical-guidelines.md`
 
+## AGENTS.md Sizing
+
+When generating or updating `AGENTS.md` during project initialization, you **MUST** follow the sizing guidelines in `docs/agents-md-guidelines.md`:
+
+- Target ~1,000 words (~1,350 tokens)
+- Include only operational per-turn guidance (agent roster, skill roster, instructions table, general rules)
+- Move reference content (workflow chains, prompt tables, verbose explanations) to `docs/`
+
 ## Final Instructions
 
 1. You **MUST NOT** start implementing anything.

--- a/.claude/skills/memo-cli-usage/REFERENCE.md
+++ b/.claude/skills/memo-cli-usage/REFERENCE.md
@@ -1,0 +1,798 @@
+# memo-cli Full Reference
+
+> This is the complete CLI documentation for `memo-cli`. For everyday usage patterns, see `SKILL.md`.
+> Agents: read this file when performing setup, configuration, admin operations, or when you need detailed flag documentation.
+
+# memo-cli Usage Skill
+
+Teach AI agents (and human developers) how to operate **memo-cli** — the agent-first CLI for capturing and querying architectural decisions stored in a shared Qdrant vector database.
+
+Use this skill whenever an agent needs to **read**, **write**, **search**, or **manage** decision entries in a repository that has `memo-cli` installed.
+
+> **Portability:** This skill is self-contained. Copy the `memo-cli-usage/` folder into any repository's `.github/skills/` directory and reference it from that repo's `AGENTS.md` or skill registry.
+
+---
+
+## Purpose
+
+`memo-cli` is the **shared memory** that keeps agents coherent across time, sessions, and projects. It is not a log. It is not a changelog. It is a curated, searchable record of the decisions that shaped the codebase — written with enough precision that anyone (human or agent) arriving days, weeks, or months later can understand **what was decided, why, and what it affected**.
+
+An agent that uses `memo-cli` well:
+
+- Narrates its reasoning as it acts, not only at the end.
+- Records the files it modifies and why those files were the right place.
+- Explains configuration and architectural choices so future agents don't re-derive them.
+- Tags entries consistently so discovery remains reliable across projects.
+
+### Success Outcomes
+
+Using memo-cli correctly SHOULD produce these outcomes:
+
+- Faster planning and implementation by reusing prior constraints and decisions.
+- Consistent execution across agents and sessions.
+- Auditable traceability from decision to issue/story, files, and commit evidence.
+- Better cross-repo contract safety when `--scope related` is used intentionally.
+
+---
+
+## Entry Purposes and Scope
+
+Every write MUST have one clear purpose. Do not combine multiple purposes into one long entry.
+
+| Purpose                    | What it captures                                     | Entry Type          | Required lifecycle tag |
+| -------------------------- | ---------------------------------------------------- | ------------------- | ---------------------- |
+| Intent                     | Planned approach, constraints, expected impact       | `decision`          | `intent`               |
+| Outcome                    | Delivered behavior and validation evidence           | `decision`          | `outcome`              |
+| Durable architecture       | Long-lived technical decisions and trade-offs        | `decision`          | `decision`             |
+| Integration contract       | Cross-boundary assumptions and compatibility details | `integration_point` | `contract`             |
+| Structural convention      | Module boundaries and naming/layout rules            | `structure`         | `structure`            |
+
+Write only reusable knowledge. Do not write routine activity noise that is already obvious from a diff.
+
+---
+
+## When to Write to memo-cli
+
+Write a memo entry **during** or **immediately after** any of these moments:
+
+| Trigger                                                                    | Entry Type               |
+| -------------------------------------------------------------------------- | ------------------------ |
+| Choosing a library, framework, or service                                  | `decision`               |
+| Choosing how to structure a module or data model                           | `decision` / `structure` |
+| Changing a config file and explaining why                                  | `decision`               |
+| Identifying or formalizing a cross-service contract                        | `integration_point`      |
+| Modifying critical files (entry points, core abstractions, schema)         | `decision`               |
+| Discovering a constraint (API limit, platform quirk, security requirement) | `decision`               |
+| Resolving a conflict between two approaches                                | `decision`               |
+| Establishing a naming or layout convention                                 | `structure`              |
+| Starting work on a story or task (intent entry)                            | `decision`               |
+| Completing a story or task (outcome entry)                                 | `decision`               |
+
+---
+
+## When to Search memo-cli
+
+Search **before** taking action, not only when stuck:
+
+| Situation                                      | Command                                               |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| Starting a session — restore context           | `memo list --limit 20 --json`                         |
+| Normalize vocabulary before writing            | `memo tags list --sort frequency --json`              |
+| Before making a design choice                  | `memo search "<topic>" --json`                        |
+| Before touching a file you haven't seen before | `memo search "<filename or module name>" --json`      |
+| Evaluating whether to add a dependency         | `memo search "<library name>" --scope related --json` |
+| Onboarding to an unfamiliar repo               | `memo inspect --json` then `memo list --json`         |
+
+### Required Read Sequence
+
+At session start, run reads in this exact order:
+
+1. `memo setup validate`
+2. `memo list --limit 20 --json`
+3. `memo tags list --sort frequency --json`
+4. `memo search "<current issue/story/title>" --limit 10 --json`
+5. `memo search "<key contract or dependency>" --scope related --limit 5 --json` (when boundary impact is expected)
+
+Before coding or planning, synthesize findings in 4 bullets:
+
+- Constraints to preserve
+- Rejected alternatives to avoid
+- Contracts/boundaries that must remain stable
+- Sensitive files/modules to treat carefully
+
+---
+
+## Minimum Entry Schema
+
+All entries SHOULD include these fields when applicable:
+
+- Scope: issue/story identifier (`issue-<n>` or `story-<id>`)
+- Context: what changed and why now
+- Decision/Delivery: what was chosen or implemented
+- Impact: downstream behavior or contracts affected
+- Evidence: commit SHA and key files (`outcome` required)
+
+Additional requirements by purpose:
+
+- Intent entries MUST include constraints/non-goals and expected files.
+- Outcome entries MUST include AC coverage and quality gate status (`test`, `lint`, `format:check`, `typecheck`, `audit`).
+- Contract entries MUST include producer, consumer, validation rules, and failure behavior.
+
+---
+
+## Tag Taxonomy Standard
+
+Tags MUST be kebab-case and ordered in these layers:
+
+1. Domain tag (for example: `auth`, `tenant`, `ingestion`, `docs`)
+2. Work-item tag (`issue-113`, `story-s003`)
+3. Lifecycle tag (`intent`, `outcome`, `decision`, `contract`, `structure`)
+4. Impact/quality tag (`security`, `migration`, `gates-pass`, `docs-drift-fixed`)
+5. Optional boundary tag (`api`, `middleware`, `cross-repo`)
+
+Use 4-5 tags whenever possible. Reuse existing tags from `memo tags list`.
+
+---
+
+## Prerequisites
+
+### Environment Variables
+
+The following variables **MUST** be set before any `memo` command will work:
+
+| Variable              | Purpose                   | Example                 |
+| --------------------- | ------------------------- | ----------------------- |
+| `QDRANT_URL`          | Qdrant instance endpoint  | `http://localhost:6333` |
+| `QDRANT_API_KEY`      | API key (empty for local) | `""` or a cloud key     |
+| `EMBEDDINGS_PROVIDER` | Embedding backend         | `openai`                |
+| `EMBEDDINGS_API_KEY`  | Provider secret key       | `sk-...`                |
+
+> **Tip:** Store these in a `.env` file at the repository root. `memo-cli` loads it automatically via `dotenv`.
+
+### Repository Configuration
+
+A `memo.config.json` **MUST** exist at the repository root. Create one with:
+
+```bash
+memo setup init --repo <repo-name> --org <org-name> --domain <domain> [--relates-to repo1,repo2]
+```
+
+Verify it at any time:
+
+```bash
+memo setup validate   # exit 0 = valid
+memo setup show       # print effective config
+```
+
+---
+
+## Core Concepts
+
+### `repo` — Repository Identity
+
+`repo` is the **name of the codebase** this entry belongs to. It is set in `memo.config.json` and defaults into every `memo write` call automatically. Use the kebab-case name of the Git repository (e.g., `memo-cli`, `auth-service`, `api-gateway`).
+
+**Why it matters:** Every entry is scoped to a repo. `memo search` and `memo list` filter by your current repo by default, so entries from other repos don't pollute your results unless you explicitly request them with `--scope related`.
+
+**Rule:** Use the repo's canonical name — the one that appears in the GitHub URL. Don't abbreviate or alias it.
+
+---
+
+### `org` — Organization
+
+`org` is the **owner or organization** that the repository belongs to. In GitHub terms, this is the account or org username (e.g., `llipe`, `acme-corp`, `my-team`).
+
+**Why it matters:** `org` groups related repositories under a common owner. It enables cross-repo queries scoped to a single organization — e.g., finding all decisions made under `acme-corp` across all its services.
+
+**Rule:** Use the GitHub organization or user handle, kebab-case. All repos under the same team should share the same `org` value.
+
+---
+
+### `domain` — Product or Functional Area
+
+`domain` describes the **product area or functional concern** that this repository serves (e.g., `auth`, `payments`, `infra`, `ai`, `search`, `notifications`). It is broader than a repository — multiple repos can share the same domain.
+
+**Why it matters:** Domain is a cross-cutting label that lets you query decisions across all repos in a functional area. For example, all `auth`-domain decisions across `auth-service`, `api-gateway`, and `user-service` can be retrieved together.
+
+**How to choose:**
+
+- Use the business or technical capability, not the team name.
+- Keep it stable — domains change less often than repos.
+- Examples: `auth`, `billing`, `data-pipeline`, `mobile`, `platform`, `ai`, `infra`, `developer-tools`.
+
+---
+
+### `relates_to` — Connected Repositories
+
+`relates_to` is an **explicit list of other repository names** that this repo has a meaningful relationship with — shared contracts, shared schemas, upstream/downstream dependencies, or simply repos that an agent often works across together.
+
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
+
+**Why it matters:** Setting `relates_to` enables `--scope related` queries, which search entries across this repo **and** all listed repos simultaneously. This is how agents and developers get cross-service context without switching repositories.
+
+**When to add a repo to `relates_to`:**
+
+- This repo consumes an API or event contract that the other repo owns.
+- Decisions in the other repo often directly constrain decisions in this one.
+- You regularly need to cross-reference both repos during feature work.
+- They share a data model or schema.
+
+**Rule:** Keep `relates_to` intentional — list real dependencies, not every repo in the org. A bloated list degrades search signal.
+
+---
+
+### Entry Types
+
+| Type                | When to use                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `decision`          | Architectural or design choices ("We chose Postgres over Mongo because…") |
+| `integration_point` | Cross-service contracts, API boundaries, shared schemas                   |
+| `structure`         | Folder layout, module boundaries, naming conventions                      |
+
+### Source
+
+| Value    | Meaning                                                        |
+| -------- | -------------------------------------------------------------- |
+| `agent`  | Written by an AI agent (default when `defaults.source` is set) |
+| `manual` | Written by a human developer                                   |
+
+### Scoping
+
+Every entry belongs to a **repo**, **org**, and **domain** (all kebab-case). Queries default to the current repo context from `memo.config.json`.
+
+- `--scope repo` — Only entries for the current repository.
+- `--scope related` — Current repository + all repos listed in `relates_to`.
+
+---
+
+## Command Reference
+
+### `memo write` — Record a Decision
+
+```bash
+memo write \
+  --rationale "Chose JWT over session cookies for stateless auth across services" \
+  --tags "auth,jwt,stateless" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+**Required flags:**
+
+- `--rationale` — The decision text (1–5 000 chars).
+- `--tags` — 2–5 comma-separated kebab-case tags.
+
+**Optional flags:**
+
+- `--entry-type` — `decision` (default) | `integration_point` | `structure`
+- `--source` — `agent` | `manual` (falls back to config default)
+- `--commit` — Git commit SHA for traceability
+- `--story` — Story or task ID
+- `--files` — Comma-separated file paths touched by the decision
+- `--relates-to` — Related repo names
+- `--on-duplicate` — `consolidate` | `update` | `replace` | `create-new`
+- `--json` — Machine-readable output (**always use in agent mode**)
+
+**Duplicate handling:**
+When memo detects a duplicate (same `repo + commit + story + entry_type + source`), interactive mode prompts for resolution. In `--json` mode you **MUST** supply `--on-duplicate` or the command will fail.
+
+---
+
+### `memo search` — Semantic Search
+
+```bash
+memo search "rate limiting strategy" --limit 5 --json
+```
+
+Natural-language vector search over decision entries.
+
+**Optional flags:**
+
+- `--scope` — `repo` (default) | `related`
+- `--tags` — Comma-separated filter (AND logic)
+- `--entry-type` — Filter by type
+- `--source` — Filter by source
+- `--limit` — Max results (default 10)
+- `--json` — Machine-readable output
+
+---
+
+### `memo list` — Chronological Browse
+
+```bash
+memo list --limit 20 --json
+```
+
+Most-recent-first listing with optional date range.
+
+**Optional flags:**
+
+- `--scope`, `--tags`, `--entry-type`, `--source` — Same as search
+- `--from` / `--to` — ISO 8601 date boundaries
+- `--limit` — Max results (default 20)
+- `--json` — Machine-readable output
+
+---
+
+### `memo tags list` — Discover Tags
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Shows all unique tags with entry counts.
+
+**Optional flags:**
+
+- `--scope` — `repo` | `related`
+- `--sort` — `alpha` (default) | `frequency`
+- `--json` — Machine-readable output
+
+---
+
+### `memo inspect` — Global Facet Discovery
+
+```bash
+memo inspect --json
+```
+
+Lists all organizations, repositories, and domains across the entire knowledge base (ignores repo scope). Useful for onboarding and cross-team exploration.
+
+**Optional flags:**
+
+- `--orgs` / `--repos` / `--domains` — Show only one facet
+- `--json` — Machine-readable output
+
+---
+
+### `memo delete` — Remove Entries
+
+**Single entry:**
+
+```bash
+memo delete --id <uuid> --json
+```
+
+**Bulk (interactive only — blocked in `--json` mode for safety):**
+
+```bash
+memo delete --all-by-repo <repo-name> --yes
+memo delete --all-by-org <org-name> --yes
+```
+
+Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
+
+---
+
+## Agent Workflows
+
+### Starting a Session — Restore Context
+
+At the **beginning of every session**, run this sequence before writing a single line of code:
+
+```bash
+# 1. Confirm config is valid
+memo setup validate
+
+# 2. Discover what repos/orgs/domains exist
+memo inspect --json
+
+# 3. Review recent decisions for this repo
+memo list --limit 20 --json
+
+# 4. Check the established tag vocabulary
+memo tags list --sort frequency --json
+
+# 5. Search for context relevant to the current task
+memo search "<current task or feature description>" --limit 10 --json
+```
+
+Read the results before proceeding. Prior entries may contain constraints, preferred patterns, or rejected alternatives that directly affect how you should approach the current task.
+
+---
+
+### Recording Decisions — As You Work, Not Only at the End
+
+Write a memo entry **at the moment you make a decision**, not as a post-hoc summary. This preserves the full reasoning before context is lost.
+
+**Template:**
+
+```bash
+memo write \
+  --rationale "CONTEXT. DECISION. RATIONALE." \
+  --tags "tag1,tag2,tag3" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --story "ISSUE-42" \
+  --files "path/to/file1.ts,path/to/file2.ts" \
+  --json
+```
+
+The `--rationale` field is the most important field. See **Writing Quality** below.
+
+---
+
+### Recording File Changes — Explain the Why
+
+When modifying a significant file (entry point, core abstraction, schema, config), record what changed and why:
+
+```bash
+memo write \
+  --rationale "Modified src/lib/config.ts to add schema_version validation. The config loader previously accepted any object; adding Zod validation ensures CLI commands fail fast on malformed configs rather than producing silent errors downstream." \
+  --tags "config,validation,config-ts,error-handling" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --files "src/lib/config.ts,src/types/config.ts" \
+  --json
+```
+
+---
+
+### Recording Configuration Decisions
+
+Configuration decisions are especially important to preserve — they often appear opaque later with no obvious rationale in the code.
+
+```bash
+memo write \
+  --rationale "Set QDRANT_COLLECTION_NAME to 'decisions' permanently rather than making it configurable. A single collection per deployment simplifies queries and access control. Multi-tenancy is achieved via repo/org payload fields, not separate collections. Reconsidering this would require a data migration." \
+  --tags "qdrant,config,multi-tenancy,collection-design" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+Configuration decisions to always record:
+
+- Environment variable semantics (what the value controls, valid ranges, defaults)
+- Feature flags and their trigger conditions
+- Schema versions and migration policies
+- Storage layout choices (collection names, index strategies, partitioning)
+- Security-related configuration (TLS, auth, CORS, rate limits)
+
+---
+
+### Intent Entry — Narrate Before Acting
+
+For significant tasks, write an **intent entry** before starting implementation. This creates a checkpoint that future sessions can find, and anchors the rationale for every decision that follows.
+
+```bash
+memo write \
+  --rationale "Starting implementation of story ISSUE-37: safe delete command. Approach: add a --yes flag for non-interactive confirmation, block --json with bulk delete flags (safety guard for agents), preview affected entries before deletion. No soft-delete; permanent removal via Qdrant point deletion. This matches the existing write/search command pattern." \
+  --tags "delete,safety,issue-37,intent" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --json
+```
+
+---
+
+### Outcome Entry — Summarize After Completing
+
+When finishing a task, write an **outcome entry** that captures what actually happened vs. what was intended:
+
+```bash
+memo write \
+  --rationale "Completed ISSUE-37 safe delete command. Shipped: --id single delete, --all-by-repo and --all-by-org bulk delete (interactive only), --yes to skip confirm, preview before deletion. Deviation from intent: bulk delete also disallowed with --json (not just flagged) after discovering Qdrant batch delete has no confirmation step. Modified: src/commands/delete.ts (new), tests/unit/commands/delete.test.ts (new)." \
+  --tags "delete,safety,issue-37,outcome" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --files "src/commands/delete.ts,tests/unit/commands/delete.test.ts" \
+  --json
+```
+
+---
+
+## Writing Quality
+
+The `--rationale` field must be **precise enough that a different developer or agent — with no prior context — can understand what was decided, why, and what it affects.** A good entry answers three questions:
+
+1. **Context** — What is the situation, constraint, or problem?
+2. **Decision** — What was chosen or done?
+3. **Rationale** — Why this choice over the alternatives?
+
+### Good vs. Bad Examples
+
+**Too vague — useless to a future reader:**
+
+> "Updated auth to use JWT."
+
+**Precise — useful across sessions and developers:**
+
+> "Switched authentication from server-side sessions to JWT (HS256, 15-min access + 7-day refresh). Sessions required sticky routing which is incompatible with the planned horizontal scaling. JWTs are stateless — any instance can validate without a shared session store. Trade-off: revocation requires a Redis blacklist (added to ISSUE-51 backlog). Files: src/auth/jwt.ts, src/middleware/auth.ts."
+
+---
+
+**Too vague:**
+
+> "Changed config validation."
+
+**Precise:**
+
+> "Added Zod validation to memo.config.json loader (src/lib/config.ts). Previously the code trusted the file's shape; malformed configs caused cryptic runtime errors deep in Qdrant queries. Now the CLI fails immediately at startup with a structured error message. This is the single place config is read — no other validation needed."
+
+---
+
+**Too vague:**
+
+> "Used Redis for caching."
+
+**Precise:**
+
+> "Chose Redis (via ioredis) over in-process LRU cache for rate-limit counters. In-process cache doesn't survive pod restarts and is not shared across replicas. Redis TTL natively aligns with the sliding window algorithm. Accepted dependency: Redis must be available in all environments. Config: REDIS_URL env var, no auth in dev, TLS required in prod."
+
+---
+
+### Structural Rule
+
+Write `--rationale` as a single coherent paragraph (or 2-3 short sentences). **Avoid bullet points** in the rationale field — they fragment reasoning and lose connective logic. Save structure for tags.
+
+Minimum viable rationale: **context sentence + decision sentence + why sentence**.
+
+---
+
+## Tag Strategy
+
+Tags are the primary way to discover entries. Good tagging makes the difference between a searchable knowledge base and an unsearchable archive.
+
+### Tag Layers
+
+Apply tags across **multiple layers** simultaneously:
+
+| Layer              | Purpose                 | Examples                                               |
+| ------------------ | ----------------------- | ------------------------------------------------------ |
+| **Domain/feature** | What area of the system | `auth`, `rate-limiting`, `config`, `delete`, `storage` |
+| **Technology**     | What tech is involved   | `qdrant`, `redis`, `openai`, `zod`, `jwt`              |
+| **Entry nature**   | What kind of change     | `intent`, `outcome`, `constraint`, `trade-off`, `adr`  |
+| **Story/task ref** | Traceability            | `issue-37`, `story-s003`, `prd-001`                    |
+| **Scope**          | How broad the impact    | `cross-repo`, `breaking-change`, `config-change`       |
+
+Every write SHOULD include tags from at least **2–3 layers**.
+
+### Before Inventing a Tag — Check What Exists
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Re-use existing tags whenever possible. Consistent vocabulary is what allows `memo search` to surface related entries from weeks ago or from a different repository.
+
+### Tag Naming Rules
+
+- Kebab-case only: `rate-limiting`, not `rateLimiting` or `rate_limiting`.
+- Prefer specific over generic: `qdrant-collection` over `database`.
+- For story/task refs: `issue-37`, `story-s003` (numeric, no spaces).
+- Session markers: `intent` (beginning of task) and `outcome` (completion).
+- For cross-cutting concerns: `breaking-change`, `security`, `performance`, `config-change`.
+
+### Tag Examples by Scenario
+
+**Architectural decision on storage:**
+
+```
+qdrant,collection-design,multi-tenancy,decision,adr
+```
+
+**Config change:**
+
+```
+config,env-vars,config-change,issue-42
+```
+
+**Integration contract between two services:**
+
+```
+api-contract,auth-service,cross-repo,integration-point,breaking-change
+```
+
+**Starting a new feature (intent):**
+
+```
+delete-command,safety,issue-37,intent
+```
+
+**Completing a feature (outcome):**
+
+```
+delete-command,safety,issue-37,outcome
+```
+
+**Performance trade-off:**
+
+```
+embeddings,openai,performance,trade-off,caching
+```
+
+---
+
+## Multi-Developer & Cross-Session Context
+
+`memo-cli` is designed so that **every agent and every developer shares the same decision history**. This is what enables continuity across days, team rotations, and parallel workstreams.
+
+### Shared Knowledge Base
+
+All entries are stored in a shared Qdrant instance. When Developer A (or Agent A) records a decision, Developer B can immediately find it via `memo search`. There is no per-user silo.
+
+### Cross-Repository Visibility
+
+Use `--scope related` to query across connected repositories:
+
+```bash
+memo search "auth contract" --scope related --json
+```
+
+This is critical for:
+
+- Microservice architectures where contracts span repos.
+- Agent workflows that touch multiple repositories in sequence.
+- Detecting when a decision in one repo contradicts a constraint in another.
+
+Configure related repos in `memo.config.json`:
+
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
+
+### Session Continuity for Agents
+
+Agents are stateless between sessions. To maintain continuity:
+
+1. **Start every session** with `memo list` and `memo search` — always.
+2. **Write an intent entry** before starting significant work.
+3. **Write as you decide**, not as a batch at the end.
+4. **Write an outcome entry** when completing a task, including any deviations from intent.
+5. **Tag consistently** — check `memo tags list` before picking tags.
+
+### Multi-Day Work Pattern
+
+For work that spans multiple days:
+
+- **Day 1 end**: Write an outcome entry with current state, what's done, what's next, any open questions.
+- **Day 2 start**: `memo search "<task name or issue number>" --json` to restore exact context.
+- The tags `intent` and `outcome` combined with a story tag (e.g., `issue-37`) make the full arc of a feature retrievable as a timeline.
+
+### What to Record vs. What to Skip
+
+| Record                                        | Skip                                                        |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| Architectural choices and their rationale     | Trivial implementation details (variable names, formatting) |
+| Technology selections with trade-off analysis | Routine bug fixes with no design impact                     |
+| Configuration changes that affect behavior    | Code style choices (use linters)                            |
+| API contracts and integration boundaries      | Dependency version bumps (use lockfile)                     |
+| Security-sensitive design choices             | Temporary workarounds expected to be removed within hours   |
+| Performance trade-offs and their context      | Generated code                                              |
+| Rejected alternatives and why                 | CI/build configuration (use config files)                   |
+| Constraints discovered during implementation  | Debugging steps                                             |
+
+---
+
+## Memory Scopes (IDE / Agent Memory vs. memo-cli)
+
+Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each prevents both redundancy and gaps.
+
+| Scope                 | Where                  | Persistence                                    | Use For                                                                                     |
+| --------------------- | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **User memory**       | `/memories/`           | All workspaces, all sessions                   | Personal preferences, debugging patterns, general agent insights                            |
+| **Session memory**    | `/memories/session/`   | Current conversation only                      | Scratch notes, in-progress state, temporary checklists                                      |
+| **Repository memory** | `/memories/repo/`      | Current workspace                              | Repo gotchas, build commands, local conventions — fast-access notes for this repo           |
+| **memo-cli**          | Qdrant (shared remote) | Permanent, shared across all people and agents | Architectural decisions, integration contracts, structural choices, configuration rationale |
+
+### Decision Tree: Where Does This Information Belong?
+
+```
+Is it a decision, rationale, constraint, contract, or config choice?
+  └─ YES → memo write  (it belongs to the shared knowledge base)
+
+Is it a repo-specific gotcha or quick operational fact?
+  └─ YES → /memories/repo/ (and also memo write if it reflects a real design choice)
+
+Is it a personal preference or general agent pattern?
+  └─ YES → /memories/ (user memory)
+
+Is it temporary context that only matters for the current session?
+  └─ YES → /memories/session/
+```
+
+**Key principle:** If the information would help a _different_ developer or agent working in the same codebase — even a year from now — it belongs in `memo-cli`.
+
+---
+
+## Safe Operation Guardrails
+
+### Non-Destructive Defaults
+
+- `memo delete` requires confirmation by default. Use `--yes` to skip only when you are certain.
+- Bulk delete (`--all-by-repo`, `--all-by-org`) is **blocked in `--json` mode** as a safety guard against accidental mass deletion by agents.
+- `memo write` detects duplicates and prompts for resolution rather than silently overwriting.
+
+### Agent Mode (`--json`)
+
+Agents **SHOULD** always pass `--json` for predictable, parseable output. Key behaviors in JSON mode:
+
+- All output is structured JSON on stdout.
+- Errors produce JSON error objects to stderr.
+- Interactive prompts are suppressed — flags must supply all decisions.
+- `--on-duplicate` is required when a duplicate is detected.
+- Bulk delete is prohibited.
+
+### Validation Before Writing
+
+Before `memo write`, agents SHOULD:
+
+1. Verify `memo setup validate` passes.
+2. Confirm tags are kebab-case (lowercase, hyphens only).
+3. Ensure rationale is meaningful (not placeholder text).
+4. Check for duplicates with `memo search` first.
+
+### Error Handling
+
+All `memo` commands exit with:
+
+- **0** — Success
+- **1** — Validation or user error (bad flags, invalid config)
+- **2** — Unexpected/infrastructure error (Qdrant down, embedding API failure)
+
+When a command fails:
+
+1. Read the error code and message from stderr.
+2. For exit code 1: fix the input and retry.
+3. For exit code 2: check connectivity (`QDRANT_URL`) and API keys before retrying.
+
+### Environment Variable Safety
+
+- **Never** log or output `EMBEDDINGS_API_KEY` or `QDRANT_API_KEY`.
+- Store credentials in `.env` (which should be in `.gitignore`).
+- For CI/CD, use secrets management rather than plaintext config.
+
+---
+
+## Quick Reference Card
+
+```
+memo setup init --repo <r> --org <o> --domain <d>   # Initialize config
+memo setup validate                                   # Verify config
+memo setup show [--json]                              # Display config
+
+memo write --rationale "..." --tags "a,b,c" [--json]  # Record decision
+memo search "query" [--scope related] [--json]         # Semantic search
+memo list [--from DATE] [--to DATE] [--json]           # Browse entries
+memo tags list [--sort frequency] [--json]             # Discover tags
+memo inspect [--json]                                  # Global facets
+memo delete --id <uuid> [--json]                       # Delete entry
+```
+
+---
+
+## Installation in Another Repository
+
+1. **Copy** the `memo-cli-usage/` folder into `<your-repo>/.github/skills/`.
+2. **Add** the skill to your agent/skill registry (e.g., `AGENTS.md`):
+   ```markdown
+   | memo-cli-usage | `.github/skills/memo-cli-usage/` | Agent guidance for memo-cli operations | Any agent |
+   ```
+3. **Install** `memo-cli` as a dev dependency:
+   ```bash
+   pnpm add -D memo-cli   # or npm install -D memo-cli
+   ```
+4. **Configure** the repository:
+   ```bash
+   npx memo setup init --repo <name> --org <org> --domain <domain>
+   ```
+5. **Set** environment variables (`.env` or CI secrets):
+   ```
+   QDRANT_URL=http://localhost:6333
+   QDRANT_API_KEY=
+   EMBEDDINGS_PROVIDER=openai
+   EMBEDDINGS_API_KEY=sk-...
+   ```
+6. The skill is now active — any agent that loads it will know how to use `memo-cli`.

--- a/.claude/skills/memo-cli-usage/SKILL.md
+++ b/.claude/skills/memo-cli-usage/SKILL.md
@@ -3,98 +3,34 @@ name: memo-cli-usage
 description: "Read and write architectural decisions to the shared memo-cli knowledge base. Use when recording or restoring cross-session context."
 ---
 
-# memo-cli Usage Skill
+# memo-cli Usage — Quick Reference
 
-Teach AI agents (and human developers) how to operate **memo-cli** — the agent-first CLI for capturing and querying architectural decisions stored in a shared Qdrant vector database.
-
-Use this skill whenever an agent needs to **read**, **write**, **search**, or **manage** decision entries in a repository that has `memo-cli` installed.
-
-> **Portability:** This skill is self-contained. Copy the `memo-cli-usage/` folder into any repository's `.claude/skills/` directory and reference it from that repo's `AGENTS.md` or skill registry.
+Operate `memo-cli` for reading and writing architectural decisions in a shared Qdrant vector database. For full CLI documentation (all flags, configuration, admin operations, schema details), see [`REFERENCE.md`](./REFERENCE.md).
 
 ---
 
-## Purpose
+## Setup Validation
 
-`memo-cli` is the **shared memory** that keeps agents coherent across time, sessions, and projects. It is not a log. It is not a changelog. It is a curated, searchable record of the decisions that shaped the codebase — written with enough precision that anyone (human or agent) arriving days, weeks, or months later can understand **what was decided, why, and what it affected**.
+```bash
+memo setup validate   # exit 0 = configured correctly
+```
 
-An agent that uses `memo-cli` well:
-
-- Narrates its reasoning as it acts, not only at the end.
-- Records the files it modifies and why those files were the right place.
-- Explains configuration and architectural choices so future agents don't re-derive them.
-- Tags entries consistently so discovery remains reliable across projects.
-
-### Success Outcomes
-
-Using memo-cli correctly SHOULD produce these outcomes:
-
-- Faster planning and implementation by reusing prior constraints and decisions.
-- Consistent execution across agents and sessions.
-- Auditable traceability from decision to issue/story, files, and commit evidence.
-- Better cross-repo contract safety when `--scope related` is used intentionally.
+If validation fails, run: `memo setup init --repo <repo> --org <org> --domain <domain>`
 
 ---
 
-## Entry Purposes and Scope
+## Session Start — Restore Context
 
-Every write MUST have one clear purpose. Do not combine multiple purposes into one long entry.
+Run before writing any code:
 
-| Purpose                    | What it captures                                     | Entry Type          | Required lifecycle tag |
-| -------------------------- | ---------------------------------------------------- | ------------------- | ---------------------- |
-| Intent                     | Planned approach, constraints, expected impact       | `decision`          | `intent`               |
-| Outcome                    | Delivered behavior and validation evidence           | `decision`          | `outcome`              |
-| Durable architecture       | Long-lived technical decisions and trade-offs        | `decision`          | `decision`             |
-| Integration contract       | Cross-boundary assumptions and compatibility details | `integration_point` | `contract`             |
-| Structural convention      | Module boundaries and naming/layout rules            | `structure`         | `structure`            |
+```bash
+memo list --limit 20 --json
+memo tags list --sort frequency --json
+memo search "<current task description>" --limit 10 --json
+memo search "<key contract or dependency>" --scope related --limit 5 --json
+```
 
-Write only reusable knowledge. Do not write routine activity noise that is already obvious from a diff.
-
----
-
-## When to Write to memo-cli
-
-Write a memo entry **during** or **immediately after** any of these moments:
-
-| Trigger                                                                    | Entry Type               |
-| -------------------------------------------------------------------------- | ------------------------ |
-| Choosing a library, framework, or service                                  | `decision`               |
-| Choosing how to structure a module or data model                           | `decision` / `structure` |
-| Changing a config file and explaining why                                  | `decision`               |
-| Identifying or formalizing a cross-service contract                        | `integration_point`      |
-| Modifying critical files (entry points, core abstractions, schema)         | `decision`               |
-| Discovering a constraint (API limit, platform quirk, security requirement) | `decision`               |
-| Resolving a conflict between two approaches                                | `decision`               |
-| Establishing a naming or layout convention                                 | `structure`              |
-| Starting work on a story or task (intent entry)                            | `decision`               |
-| Completing a story or task (outcome entry)                                 | `decision`               |
-
----
-
-## When to Search memo-cli
-
-Search **before** taking action, not only when stuck:
-
-| Situation                                      | Command                                               |
-| ---------------------------------------------- | ----------------------------------------------------- |
-| Starting a session — restore context           | `memo list --limit 20 --json`                         |
-| Normalize vocabulary before writing            | `memo tags list --sort frequency --json`              |
-| Before making a design choice                  | `memo search "<topic>" --json`                        |
-| Before touching a file you haven't seen before | `memo search "<filename or module name>" --json`      |
-| Evaluating whether to add a dependency         | `memo search "<library name>" --scope related --json` |
-| Onboarding to an unfamiliar repo               | `memo inspect --json` then `memo list --json`         |
-
-### Required Read Sequence
-
-At session start, run reads in this exact order:
-
-1. `memo setup validate`
-2. `memo list --limit 20 --json`
-3. `memo tags list --sort frequency --json`
-4. `memo search "<current issue/story/title>" --limit 10 --json`
-5. `memo search "<key contract or dependency>" --scope related --limit 5 --json` (when boundary impact is expected)
-
-Before coding or planning, synthesize findings in 4 bullets:
-
+Synthesize findings into:
 - Constraints to preserve
 - Rejected alternatives to avoid
 - Contracts/boundaries that must remain stable
@@ -102,697 +38,106 @@ Before coding or planning, synthesize findings in 4 bullets:
 
 ---
 
-## Minimum Entry Schema
+## Writing Entries
 
-All entries SHOULD include these fields when applicable:
-
-- Scope: issue/story identifier (`issue-<n>` or `story-<id>`)
-- Context: what changed and why now
-- Decision/Delivery: what was chosen or implemented
-- Impact: downstream behavior or contracts affected
-- Evidence: commit SHA and key files (`outcome` required)
-
-Additional requirements by purpose:
-
-- Intent entries MUST include constraints/non-goals and expected files.
-- Outcome entries MUST include AC coverage and quality gate status (`test`, `lint`, `format:check`, `typecheck`, `audit`).
-- Contract entries MUST include producer, consumer, validation rules, and failure behavior.
-
----
-
-## Tag Taxonomy Standard
-
-Tags MUST be kebab-case and ordered in these layers:
-
-1. Domain tag (for example: `auth`, `tenant`, `ingestion`, `docs`)
-2. Work-item tag (`issue-113`, `story-s003`)
-3. Lifecycle tag (`intent`, `outcome`, `decision`, `contract`, `structure`)
-4. Impact/quality tag (`security`, `migration`, `gates-pass`, `docs-drift-fixed`)
-5. Optional boundary tag (`api`, `middleware`, `cross-repo`)
-
-Use 4-5 tags whenever possible. Reuse existing tags from `memo tags list`.
-
----
-
-## Prerequisites
-
-### Environment Variables
-
-The following variables **MUST** be set before any `memo` command will work:
-
-| Variable              | Purpose                   | Example                 |
-| --------------------- | ------------------------- | ----------------------- |
-| `QDRANT_URL`          | Qdrant instance endpoint  | `http://localhost:6333` |
-| `QDRANT_API_KEY`      | API key (empty for local) | `""` or a cloud key     |
-| `EMBEDDINGS_PROVIDER` | Embedding backend         | `openai`                |
-| `EMBEDDINGS_API_KEY`  | Provider secret key       | `sk-...`                |
-
-> **Tip:** Store these in a `.env` file at the repository root. `memo-cli` loads it automatically via `dotenv`.
-
-### Repository Configuration
-
-A `memo.config.json` **MUST** exist at the repository root. Create one with:
-
-```bash
-memo setup init --repo <repo-name> --org <org-name> --domain <domain> [--relates-to repo1,repo2]
-```
-
-Verify it at any time:
-
-```bash
-memo setup validate   # exit 0 = valid
-memo setup show       # print effective config
-```
-
----
-
-## Core Concepts
-
-### `repo` — Repository Identity
-
-`repo` is the **name of the codebase** this entry belongs to. It is set in `memo.config.json` and defaults into every `memo write` call automatically. Use the kebab-case name of the Git repository (e.g., `memo-cli`, `auth-service`, `api-gateway`).
-
-**Why it matters:** Every entry is scoped to a repo. `memo search` and `memo list` filter by your current repo by default, so entries from other repos don't pollute your results unless you explicitly request them with `--scope related`.
-
-**Rule:** Use the repo's canonical name — the one that appears in the GitHub URL. Don't abbreviate or alias it.
-
----
-
-### `org` — Organization
-
-`org` is the **owner or organization** that the repository belongs to. In GitHub terms, this is the account or org username (e.g., `llipe`, `acme-corp`, `my-team`).
-
-**Why it matters:** `org` groups related repositories under a common owner. It enables cross-repo queries scoped to a single organization — e.g., finding all decisions made under `acme-corp` across all its services.
-
-**Rule:** Use the GitHub organization or user handle, kebab-case. All repos under the same team should share the same `org` value.
-
----
-
-### `domain` — Product or Functional Area
-
-`domain` describes the **product area or functional concern** that this repository serves (e.g., `auth`, `payments`, `infra`, `ai`, `search`, `notifications`). It is broader than a repository — multiple repos can share the same domain.
-
-**Why it matters:** Domain is a cross-cutting label that lets you query decisions across all repos in a functional area. For example, all `auth`-domain decisions across `auth-service`, `api-gateway`, and `user-service` can be retrieved together.
-
-**How to choose:**
-
-- Use the business or technical capability, not the team name.
-- Keep it stable — domains change less often than repos.
-- Examples: `auth`, `billing`, `data-pipeline`, `mobile`, `platform`, `ai`, `infra`, `developer-tools`.
-
----
-
-### `relates_to` — Connected Repositories
-
-`relates_to` is an **explicit list of other repository names** that this repo has a meaningful relationship with — shared contracts, shared schemas, upstream/downstream dependencies, or simply repos that an agent often works across together.
-
-```json
-{
-  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
-}
-```
-
-**Why it matters:** Setting `relates_to` enables `--scope related` queries, which search entries across this repo **and** all listed repos simultaneously. This is how agents and developers get cross-service context without switching repositories.
-
-**When to add a repo to `relates_to`:**
-
-- This repo consumes an API or event contract that the other repo owns.
-- Decisions in the other repo often directly constrain decisions in this one.
-- You regularly need to cross-reference both repos during feature work.
-- They share a data model or schema.
-
-**Rule:** Keep `relates_to` intentional — list real dependencies, not every repo in the org. A bloated list degrades search signal.
-
----
-
-### Entry Types
-
-| Type                | When to use                                                               |
-| ------------------- | ------------------------------------------------------------------------- |
-| `decision`          | Architectural or design choices ("We chose Postgres over Mongo because…") |
-| `integration_point` | Cross-service contracts, API boundaries, shared schemas                   |
-| `structure`         | Folder layout, module boundaries, naming conventions                      |
-
-### Source
-
-| Value    | Meaning                                                        |
-| -------- | -------------------------------------------------------------- |
-| `agent`  | Written by an AI agent (default when `defaults.source` is set) |
-| `manual` | Written by a human developer                                   |
-
-### Scoping
-
-Every entry belongs to a **repo**, **org**, and **domain** (all kebab-case). Queries default to the current repo context from `memo.config.json`.
-
-- `--scope repo` — Only entries for the current repository.
-- `--scope related` — Current repository + all repos listed in `relates_to`.
-
----
-
-## Command Reference
-
-### `memo write` — Record a Decision
+### Intent Entry (before starting a story/task)
 
 ```bash
 memo write \
-  --rationale "Chose JWT over session cookies for stateless auth across services" \
-  --tags "auth,jwt,stateless" \
+  --rationale "Context: Starting ISSUE-<##> because <trigger>. Decision: implement via <approach>, preserving <constraints>. Impact: affects <modules/contracts>." \
+  --tags "<domain>,issue-<number>,intent,<impact-tag>" \
   --entry-type decision \
   --source agent \
+  --story "ISSUE-<number>" \
+  --on-duplicate consolidate \
   --json
 ```
 
-**Required flags:**
-
-- `--rationale` — The decision text (1–5 000 chars).
-- `--tags` — 2–5 comma-separated kebab-case tags.
-
-**Optional flags:**
-
-- `--entry-type` — `decision` (default) | `integration_point` | `structure`
-- `--source` — `agent` | `manual` (falls back to config default)
-- `--commit` — Git commit SHA for traceability
-- `--story` — Story or task ID
-- `--files` — Comma-separated file paths touched by the decision
-- `--relates-to` — Related repo names
-- `--on-duplicate` — `consolidate` | `update` | `replace` | `create-new`
-- `--json` — Machine-readable output (**always use in agent mode**)
-
-**Duplicate handling:**
-When memo detects a duplicate (same `repo + commit + story + entry_type + source`), interactive mode prompts for resolution. In `--json` mode you **MUST** supply `--on-duplicate` or the command will fail.
-
----
-
-### `memo search` — Semantic Search
-
-```bash
-memo search "rate limiting strategy" --limit 5 --json
-```
-
-Natural-language vector search over decision entries.
-
-**Optional flags:**
-
-- `--scope` — `repo` (default) | `related`
-- `--tags` — Comma-separated filter (AND logic)
-- `--entry-type` — Filter by type
-- `--source` — Filter by source
-- `--limit` — Max results (default 10)
-- `--json` — Machine-readable output
-
----
-
-### `memo list` — Chronological Browse
-
-```bash
-memo list --limit 20 --json
-```
-
-Most-recent-first listing with optional date range.
-
-**Optional flags:**
-
-- `--scope`, `--tags`, `--entry-type`, `--source` — Same as search
-- `--from` / `--to` — ISO 8601 date boundaries
-- `--limit` — Max results (default 20)
-- `--json` — Machine-readable output
-
----
-
-### `memo tags list` — Discover Tags
-
-```bash
-memo tags list --sort frequency --json
-```
-
-Shows all unique tags with entry counts.
-
-**Optional flags:**
-
-- `--scope` — `repo` | `related`
-- `--sort` — `alpha` (default) | `frequency`
-- `--json` — Machine-readable output
-
----
-
-### `memo inspect` — Global Facet Discovery
-
-```bash
-memo inspect --json
-```
-
-Lists all organizations, repositories, and domains across the entire knowledge base (ignores repo scope). Useful for onboarding and cross-team exploration.
-
-**Optional flags:**
-
-- `--orgs` / `--repos` / `--domains` — Show only one facet
-- `--json` — Machine-readable output
-
----
-
-### `memo delete` — Remove Entries
-
-**Single entry:**
-
-```bash
-memo delete --id <uuid> --json
-```
-
-**Bulk (interactive only — blocked in `--json` mode for safety):**
-
-```bash
-memo delete --all-by-repo <repo-name> --yes
-memo delete --all-by-org <org-name> --yes
-```
-
-Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
-
----
-
-## Agent Workflows
-
-### Starting a Session — Restore Context
-
-At the **beginning of every session**, run this sequence before writing a single line of code:
-
-```bash
-# 1. Confirm config is valid
-memo setup validate
-
-# 2. Discover what repos/orgs/domains exist
-memo inspect --json
-
-# 3. Review recent decisions for this repo
-memo list --limit 20 --json
-
-# 4. Check the established tag vocabulary
-memo tags list --sort frequency --json
-
-# 5. Search for context relevant to the current task
-memo search "<current task or feature description>" --limit 10 --json
-```
-
-Read the results before proceeding. Prior entries may contain constraints, preferred patterns, or rejected alternatives that directly affect how you should approach the current task.
-
----
-
-### Recording Decisions — As You Work, Not Only at the End
-
-Write a memo entry **at the moment you make a decision**, not as a post-hoc summary. This preserves the full reasoning before context is lost.
-
-**Template:**
+### Outcome Entry (after completing a story/task)
 
 ```bash
 memo write \
-  --rationale "CONTEXT. DECISION. RATIONALE." \
-  --tags "tag1,tag2,tag3" \
+  --rationale "Context: Completed ISSUE-<##>. Delivery: shipped <behavior>, deviations <none|details>, AC <x/y> verified. Impact: quality gates test=<p/f>; lint=<p/f>; format:check=<p/f>; typecheck=<p/f>; audit=<p/f>." \
+  --tags "<domain>,issue-<number>,outcome,gates-pass" \
   --entry-type decision \
   --source agent \
   --commit "$(git rev-parse HEAD)" \
-  --story "ISSUE-42" \
-  --files "path/to/file1.ts,path/to/file2.ts" \
+  --story "ISSUE-<number>" \
+  --files "<key files modified>" \
+  --on-duplicate consolidate \
   --json
 ```
 
-The `--rationale` field is the most important field. See **Writing Quality** below.
-
----
-
-### Recording File Changes — Explain the Why
-
-When modifying a significant file (entry point, core abstraction, schema, config), record what changed and why:
+### Decision Entry (architectural choices)
 
 ```bash
 memo write \
-  --rationale "Modified src/lib/config.ts to add schema_version validation. The config loader previously accepted any object; adding Zod validation ensures CLI commands fail fast on malformed configs rather than producing silent errors downstream." \
-  --tags "config,validation,config-ts,error-handling" \
-  --entry-type decision \
-  --source agent \
-  --commit "$(git rev-parse HEAD)" \
-  --files "src/lib/config.ts,src/types/config.ts" \
-  --json
-```
-
----
-
-### Recording Configuration Decisions
-
-Configuration decisions are especially important to preserve — they often appear opaque later with no obvious rationale in the code.
-
-```bash
-memo write \
-  --rationale "Set QDRANT_COLLECTION_NAME to 'decisions' permanently rather than making it configurable. A single collection per deployment simplifies queries and access control. Multi-tenancy is achieved via repo/org payload fields, not separate collections. Reconsidering this would require a data migration." \
-  --tags "qdrant,config,multi-tenancy,collection-design" \
+  --rationale "Context: <situation>. Decision: <what was chosen>. Rationale: <why this over alternatives>." \
+  --tags "<domain>,<technology>,decision" \
   --entry-type decision \
   --source agent \
   --json
 ```
 
-Configuration decisions to always record:
+---
 
-- Environment variable semantics (what the value controls, valid ranges, defaults)
-- Feature flags and their trigger conditions
-- Schema versions and migration policies
-- Storage layout choices (collection names, index strategies, partitioning)
-- Security-related configuration (TLS, auth, CORS, rate limits)
+## Entry Types
+
+| Type | Use For |
+|------|---------|
+| `decision` | Architectural/design choices, intent, outcome |
+| `integration_point` | Cross-service contracts, API boundaries |
+| `structure` | Module layout, naming conventions |
 
 ---
 
-### Intent Entry — Narrate Before Acting
+## Tag Rules
 
-For significant tasks, write an **intent entry** before starting implementation. This creates a checkpoint that future sessions can find, and anchors the rationale for every decision that follows.
-
-```bash
-memo write \
-  --rationale "Starting implementation of story ISSUE-37: safe delete command. Approach: add a --yes flag for non-interactive confirmation, block --json with bulk delete flags (safety guard for agents), preview affected entries before deletion. No soft-delete; permanent removal via Qdrant point deletion. This matches the existing write/search command pattern." \
-  --tags "delete,safety,issue-37,intent" \
-  --entry-type decision \
-  --source agent \
-  --story "ISSUE-37" \
-  --json
-```
+- Kebab-case only: `rate-limiting` not `rateLimiting`
+- 4-5 tags per entry across layers: domain, work-item, lifecycle, impact, boundary
+- Check existing tags first: `memo tags list --sort frequency --json`
+- Reuse over inventing new tags
 
 ---
 
-### Outcome Entry — Summarize After Completing
+## When to Write
 
-When finishing a task, write an **outcome entry** that captures what actually happened vs. what was intended:
-
-```bash
-memo write \
-  --rationale "Completed ISSUE-37 safe delete command. Shipped: --id single delete, --all-by-repo and --all-by-org bulk delete (interactive only), --yes to skip confirm, preview before deletion. Deviation from intent: bulk delete also disallowed with --json (not just flagged) after discovering Qdrant batch delete has no confirmation step. Modified: src/commands/delete.ts (new), tests/unit/commands/delete.test.ts (new)." \
-  --tags "delete,safety,issue-37,outcome" \
-  --entry-type decision \
-  --source agent \
-  --story "ISSUE-37" \
-  --files "src/commands/delete.ts,tests/unit/commands/delete.test.ts" \
-  --json
-```
+- Choosing a library, framework, or architecture pattern
+- Changing config files (explain why)
+- Modifying core abstractions, schemas, entry points
+- Establishing naming/layout conventions
+- Discovering constraints (API limits, platform quirks)
+- Starting/completing a story (intent/outcome)
 
 ---
 
-## Writing Quality
+## When to Search
 
-The `--rationale` field must be **precise enough that a different developer or agent — with no prior context — can understand what was decided, why, and what it affects.** A good entry answers three questions:
-
-1. **Context** — What is the situation, constraint, or problem?
-2. **Decision** — What was chosen or done?
-3. **Rationale** — Why this choice over the alternatives?
-
-### Good vs. Bad Examples
-
-**Too vague — useless to a future reader:**
-
-> "Updated auth to use JWT."
-
-**Precise — useful across sessions and developers:**
-
-> "Switched authentication from server-side sessions to JWT (HS256, 15-min access + 7-day refresh). Sessions required sticky routing which is incompatible with the planned horizontal scaling. JWTs are stateless — any instance can validate without a shared session store. Trade-off: revocation requires a Redis blacklist (added to ISSUE-51 backlog). Files: src/auth/jwt.ts, src/middleware/auth.ts."
+- Before making design choices: `memo search "<topic>" --json`
+- Before touching unfamiliar files: `memo search "<filename>" --json`
+- Cross-repo context: `memo search "<query>" --scope related --json`
 
 ---
 
-**Too vague:**
+## Agent Mode Rules
 
-> "Changed config validation."
-
-**Precise:**
-
-> "Added Zod validation to memo.config.json loader (src/lib/config.ts). Previously the code trusted the file's shape; malformed configs caused cryptic runtime errors deep in Qdrant queries. Now the CLI fails immediately at startup with a structured error message. This is the single place config is read — no other validation needed."
-
----
-
-**Too vague:**
-
-> "Used Redis for caching."
-
-**Precise:**
-
-> "Chose Redis (via ioredis) over in-process LRU cache for rate-limit counters. In-process cache doesn't survive pod restarts and is not shared across replicas. Redis TTL natively aligns with the sliding window algorithm. Accepted dependency: Redis must be available in all environments. Config: REDIS_URL env var, no auth in dev, TLS required in prod."
+- Always pass `--json` for parseable output
+- Always pass `--on-duplicate consolidate` for writes
+- Never log API keys or secrets
+- Bulk delete is blocked in `--json` mode (safety guard)
 
 ---
 
-### Structural Rule
-
-Write `--rationale` as a single coherent paragraph (or 2-3 short sentences). **Avoid bullet points** in the rationale field — they fragment reasoning and lose connective logic. Save structure for tags.
-
-Minimum viable rationale: **context sentence + decision sentence + why sentence**.
-
----
-
-## Tag Strategy
-
-Tags are the primary way to discover entries. Good tagging makes the difference between a searchable knowledge base and an unsearchable archive.
-
-### Tag Layers
-
-Apply tags across **multiple layers** simultaneously:
-
-| Layer              | Purpose                 | Examples                                               |
-| ------------------ | ----------------------- | ------------------------------------------------------ |
-| **Domain/feature** | What area of the system | `auth`, `rate-limiting`, `config`, `delete`, `storage` |
-| **Technology**     | What tech is involved   | `qdrant`, `redis`, `openai`, `zod`, `jwt`              |
-| **Entry nature**   | What kind of change     | `intent`, `outcome`, `constraint`, `trade-off`, `adr`  |
-| **Story/task ref** | Traceability            | `issue-37`, `story-s003`, `prd-001`                    |
-| **Scope**          | How broad the impact    | `cross-repo`, `breaking-change`, `config-change`       |
-
-Every write SHOULD include tags from at least **2–3 layers**.
-
-### Before Inventing a Tag — Check What Exists
-
-```bash
-memo tags list --sort frequency --json
-```
-
-Re-use existing tags whenever possible. Consistent vocabulary is what allows `memo search` to surface related entries from weeks ago or from a different repository.
-
-### Tag Naming Rules
-
-- Kebab-case only: `rate-limiting`, not `rateLimiting` or `rate_limiting`.
-- Prefer specific over generic: `qdrant-collection` over `database`.
-- For story/task refs: `issue-37`, `story-s003` (numeric, no spaces).
-- Session markers: `intent` (beginning of task) and `outcome` (completion).
-- For cross-cutting concerns: `breaking-change`, `security`, `performance`, `config-change`.
-
-### Tag Examples by Scenario
-
-**Architectural decision on storage:**
+## Quick Command Card
 
 ```
-qdrant,collection-design,multi-tenancy,decision,adr
-```
-
-**Config change:**
-
-```
-config,env-vars,config-change,issue-42
-```
-
-**Integration contract between two services:**
-
-```
-api-contract,auth-service,cross-repo,integration-point,breaking-change
-```
-
-**Starting a new feature (intent):**
-
-```
-delete-command,safety,issue-37,intent
-```
-
-**Completing a feature (outcome):**
-
-```
-delete-command,safety,issue-37,outcome
-```
-
-**Performance trade-off:**
-
-```
-embeddings,openai,performance,trade-off,caching
-```
-
----
-
-## Multi-Developer & Cross-Session Context
-
-`memo-cli` is designed so that **every agent and every developer shares the same decision history**. This is what enables continuity across days, team rotations, and parallel workstreams.
-
-### Shared Knowledge Base
-
-All entries are stored in a shared Qdrant instance. When Developer A (or Agent A) records a decision, Developer B can immediately find it via `memo search`. There is no per-user silo.
-
-### Cross-Repository Visibility
-
-Use `--scope related` to query across connected repositories:
-
-```bash
-memo search "auth contract" --scope related --json
-```
-
-This is critical for:
-
-- Microservice architectures where contracts span repos.
-- Agent workflows that touch multiple repositories in sequence.
-- Detecting when a decision in one repo contradicts a constraint in another.
-
-Configure related repos in `memo.config.json`:
-
-```json
-{
-  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
-}
-```
-
-### Session Continuity for Agents
-
-Agents are stateless between sessions. To maintain continuity:
-
-1. **Start every session** with `memo list` and `memo search` — always.
-2. **Write an intent entry** before starting significant work.
-3. **Write as you decide**, not as a batch at the end.
-4. **Write an outcome entry** when completing a task, including any deviations from intent.
-5. **Tag consistently** — check `memo tags list` before picking tags.
-
-### Multi-Day Work Pattern
-
-For work that spans multiple days:
-
-- **Day 1 end**: Write an outcome entry with current state, what's done, what's next, any open questions.
-- **Day 2 start**: `memo search "<task name or issue number>" --json` to restore exact context.
-- The tags `intent` and `outcome` combined with a story tag (e.g., `issue-37`) make the full arc of a feature retrievable as a timeline.
-
-### What to Record vs. What to Skip
-
-| Record                                        | Skip                                                        |
-| --------------------------------------------- | ----------------------------------------------------------- |
-| Architectural choices and their rationale     | Trivial implementation details (variable names, formatting) |
-| Technology selections with trade-off analysis | Routine bug fixes with no design impact                     |
-| Configuration changes that affect behavior    | Code style choices (use linters)                            |
-| API contracts and integration boundaries      | Dependency version bumps (use lockfile)                     |
-| Security-sensitive design choices             | Temporary workarounds expected to be removed within hours   |
-| Performance trade-offs and their context      | Generated code                                              |
-| Rejected alternatives and why                 | CI/build configuration (use config files)                   |
-| Constraints discovered during implementation  | Debugging steps                                             |
-
----
-
-## Memory Scopes (IDE / Agent Memory vs. memo-cli)
-
-Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each prevents both redundancy and gaps.
-
-| Scope                 | Where                  | Persistence                                    | Use For                                                                                     |
-| --------------------- | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **User memory**       | `/memories/`           | All workspaces, all sessions                   | Personal preferences, debugging patterns, general agent insights                            |
-| **Session memory**    | `/memories/session/`   | Current conversation only                      | Scratch notes, in-progress state, temporary checklists                                      |
-| **Repository memory** | `/memories/repo/`      | Current workspace                              | Repo gotchas, build commands, local conventions — fast-access notes for this repo           |
-| **memo-cli**          | Qdrant (shared remote) | Permanent, shared across all people and agents | Architectural decisions, integration contracts, structural choices, configuration rationale |
-
-### Decision Tree: Where Does This Information Belong?
-
-```
-Is it a decision, rationale, constraint, contract, or config choice?
-  └─ YES → memo write  (it belongs to the shared knowledge base)
-
-Is it a repo-specific gotcha or quick operational fact?
-  └─ YES → /memories/repo/ (and also memo write if it reflects a real design choice)
-
-Is it a personal preference or general agent pattern?
-  └─ YES → /memories/ (user memory)
-
-Is it temporary context that only matters for the current session?
-  └─ YES → /memories/session/
-```
-
-**Key principle:** If the information would help a _different_ developer or agent working in the same codebase — even a year from now — it belongs in `memo-cli`.
-
----
-
-## Safe Operation Guardrails
-
-### Non-Destructive Defaults
-
-- `memo delete` requires confirmation by default. Use `--yes` to skip only when you are certain.
-- Bulk delete (`--all-by-repo`, `--all-by-org`) is **blocked in `--json` mode** as a safety guard against accidental mass deletion by agents.
-- `memo write` detects duplicates and prompts for resolution rather than silently overwriting.
-
-### Agent Mode (`--json`)
-
-Agents **SHOULD** always pass `--json` for predictable, parseable output. Key behaviors in JSON mode:
-
-- All output is structured JSON on stdout.
-- Errors produce JSON error objects to stderr.
-- Interactive prompts are suppressed — flags must supply all decisions.
-- `--on-duplicate` is required when a duplicate is detected.
-- Bulk delete is prohibited.
-
-### Validation Before Writing
-
-Before `memo write`, agents SHOULD:
-
-1. Verify `memo setup validate` passes.
-2. Confirm tags are kebab-case (lowercase, hyphens only).
-3. Ensure rationale is meaningful (not placeholder text).
-4. Check for duplicates with `memo search` first.
-
-### Error Handling
-
-All `memo` commands exit with:
-
-- **0** — Success
-- **1** — Validation or user error (bad flags, invalid config)
-- **2** — Unexpected/infrastructure error (Qdrant down, embedding API failure)
-
-When a command fails:
-
-1. Read the error code and message from stderr.
-2. For exit code 1: fix the input and retry.
-3. For exit code 2: check connectivity (`QDRANT_URL`) and API keys before retrying.
-
-### Environment Variable Safety
-
-- **Never** log or output `EMBEDDINGS_API_KEY` or `QDRANT_API_KEY`.
-- Store credentials in `.env` (which should be in `.gitignore`).
-- For CI/CD, use secrets management rather than plaintext config.
-
----
-
-## Quick Reference Card
-
-```
-memo setup init --repo <r> --org <o> --domain <d>   # Initialize config
 memo setup validate                                   # Verify config
-memo setup show [--json]                              # Display config
-
-memo write --rationale "..." --tags "a,b,c" [--json]  # Record decision
-memo search "query" [--scope related] [--json]         # Semantic search
-memo list [--from DATE] [--to DATE] [--json]           # Browse entries
-memo tags list [--sort frequency] [--json]             # Discover tags
-memo inspect [--json]                                  # Global facets
-memo delete --id <uuid> [--json]                       # Delete entry
+memo write --rationale "..." --tags "a,b,c" --json    # Record decision
+memo search "query" [--scope related] --json          # Semantic search
+memo list [--limit N] --json                          # Browse recent
+memo tags list [--sort frequency] --json              # Discover tags
+memo inspect --json                                   # Global facets
+memo delete --id <uuid> --json                        # Delete entry
 ```
 
----
-
-## Installation in Another Repository
-
-1. **Copy** the `memo-cli-usage/` folder into `<your-repo>/.claude/skills/`.
-2. **Add** the skill to your agent/skill registry (e.g., `AGENTS.md`):
-   ```markdown
-   | memo-cli-usage | `.claude/skills/memo-cli-usage/` | Agent guidance for memo-cli operations | Any agent |
-   ```
-3. **Install** `memo-cli` as a dev dependency:
-   ```bash
-   pnpm add -D memo-cli   # or npm install -D memo-cli
-   ```
-4. **Configure** the repository:
-   ```bash
-   npx memo setup init --repo <name> --org <org> --domain <domain>
-   ```
-5. **Set** environment variables (`.env` or CI secrets):
-   ```
-   QDRANT_URL=http://localhost:6333
-   QDRANT_API_KEY=
-   EMBEDDINGS_PROVIDER=openai
-   EMBEDDINGS_API_KEY=sk-...
-   ```
-6. The skill is now active — any agent that loads it will know how to use `memo-cli`.
+> For full flag documentation, admin operations, environment setup, and detailed examples, read [`REFERENCE.md`](./REFERENCE.md).

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -49,6 +49,12 @@ If the user provides a feature description or asks to create a PRD/spec/stories 
 
 ---
 
+## Steering Context Check
+
+> If no `workstream/tasks-*.md` file is open or referenced, load the implement steering by opening the relevant task file first. The implement playbook only activates when a matching workstream file is in context.
+
+---
+
 ## Non-Negotiable Operating Rules
 
 1. **Execute only:** You **MUST** only implement from existing task lists. You **MUST NOT** create PRDs, specifications, user stories, or refine scope. Redirect preparation requests to `product-engineer`.

--- a/.github/agents/product-engineer.agent.md
+++ b/.github/agents/product-engineer.agent.md
@@ -53,6 +53,12 @@ If any required input is missing, you **MUST** ask concise clarifying questions.
 
 ---
 
+## Steering Context Check
+
+> If no workstream planning artifact is open or referenced, open the relevant workstream file to ensure plan guidance loads. The plan playbook only activates when a matching workstream file is in context.
+
+---
+
 ## memo-cli Integration (When Available)
 
 ### Availability Check

--- a/.github/instructions/domain/nextjs-pages-components.instructions.md
+++ b/.github/instructions/domain/nextjs-pages-components.instructions.md
@@ -1,6 +1,8 @@
 ---
-applyTo: "**/*.tsx"
+applyTo: "**/app/**/*.tsx"
 ---
+
+<!-- Consumers: adjust applyTo to match your Next.js app path. For React Native projects, replace with a react-native steering file (see issue #13). -->
 
 # Rule: Keep Next.js Pages and React Components Consistent
 

--- a/.github/instructions/implement.instructions.md
+++ b/.github/instructions/implement.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**"
+applyTo: "workstream/**/tasks-*.md"
 ---
 
 # Activity: Implement Task List

--- a/.github/instructions/plan.instructions.md
+++ b/.github/instructions/plan.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**"
+applyTo: "workstream/**"
 ---
 
 # Activity: Plan Implementation

--- a/.github/skills/activity-init/SKILL.md
+++ b/.github/skills/activity-init/SKILL.md
@@ -139,6 +139,14 @@ When the project includes JavaScript/TypeScript:
 - **Location:** `/docs/`
 - **Filenames:** `product-context.md`, `technical-guidelines.md`
 
+## AGENTS.md Sizing
+
+When generating or updating `AGENTS.md` during project initialization, you **MUST** follow the sizing guidelines in `docs/agents-md-guidelines.md`:
+
+- Target ~1,000 words (~1,350 tokens)
+- Include only operational per-turn guidance (agent roster, skill roster, instructions table, general rules)
+- Move reference content (workflow chains, prompt tables, verbose explanations) to `docs/`
+
 ## Final Instructions
 
 1. You **MUST NOT** start implementing anything.

--- a/.github/skills/memo-cli-usage/REFERENCE.md
+++ b/.github/skills/memo-cli-usage/REFERENCE.md
@@ -1,0 +1,798 @@
+# memo-cli Full Reference
+
+> This is the complete CLI documentation for `memo-cli`. For everyday usage patterns, see `SKILL.md`.
+> Agents: read this file when performing setup, configuration, admin operations, or when you need detailed flag documentation.
+
+# memo-cli Usage Skill
+
+Teach AI agents (and human developers) how to operate **memo-cli** — the agent-first CLI for capturing and querying architectural decisions stored in a shared Qdrant vector database.
+
+Use this skill whenever an agent needs to **read**, **write**, **search**, or **manage** decision entries in a repository that has `memo-cli` installed.
+
+> **Portability:** This skill is self-contained. Copy the `memo-cli-usage/` folder into any repository's `.github/skills/` directory and reference it from that repo's `AGENTS.md` or skill registry.
+
+---
+
+## Purpose
+
+`memo-cli` is the **shared memory** that keeps agents coherent across time, sessions, and projects. It is not a log. It is not a changelog. It is a curated, searchable record of the decisions that shaped the codebase — written with enough precision that anyone (human or agent) arriving days, weeks, or months later can understand **what was decided, why, and what it affected**.
+
+An agent that uses `memo-cli` well:
+
+- Narrates its reasoning as it acts, not only at the end.
+- Records the files it modifies and why those files were the right place.
+- Explains configuration and architectural choices so future agents don't re-derive them.
+- Tags entries consistently so discovery remains reliable across projects.
+
+### Success Outcomes
+
+Using memo-cli correctly SHOULD produce these outcomes:
+
+- Faster planning and implementation by reusing prior constraints and decisions.
+- Consistent execution across agents and sessions.
+- Auditable traceability from decision to issue/story, files, and commit evidence.
+- Better cross-repo contract safety when `--scope related` is used intentionally.
+
+---
+
+## Entry Purposes and Scope
+
+Every write MUST have one clear purpose. Do not combine multiple purposes into one long entry.
+
+| Purpose                    | What it captures                                     | Entry Type          | Required lifecycle tag |
+| -------------------------- | ---------------------------------------------------- | ------------------- | ---------------------- |
+| Intent                     | Planned approach, constraints, expected impact       | `decision`          | `intent`               |
+| Outcome                    | Delivered behavior and validation evidence           | `decision`          | `outcome`              |
+| Durable architecture       | Long-lived technical decisions and trade-offs        | `decision`          | `decision`             |
+| Integration contract       | Cross-boundary assumptions and compatibility details | `integration_point` | `contract`             |
+| Structural convention      | Module boundaries and naming/layout rules            | `structure`         | `structure`            |
+
+Write only reusable knowledge. Do not write routine activity noise that is already obvious from a diff.
+
+---
+
+## When to Write to memo-cli
+
+Write a memo entry **during** or **immediately after** any of these moments:
+
+| Trigger                                                                    | Entry Type               |
+| -------------------------------------------------------------------------- | ------------------------ |
+| Choosing a library, framework, or service                                  | `decision`               |
+| Choosing how to structure a module or data model                           | `decision` / `structure` |
+| Changing a config file and explaining why                                  | `decision`               |
+| Identifying or formalizing a cross-service contract                        | `integration_point`      |
+| Modifying critical files (entry points, core abstractions, schema)         | `decision`               |
+| Discovering a constraint (API limit, platform quirk, security requirement) | `decision`               |
+| Resolving a conflict between two approaches                                | `decision`               |
+| Establishing a naming or layout convention                                 | `structure`              |
+| Starting work on a story or task (intent entry)                            | `decision`               |
+| Completing a story or task (outcome entry)                                 | `decision`               |
+
+---
+
+## When to Search memo-cli
+
+Search **before** taking action, not only when stuck:
+
+| Situation                                      | Command                                               |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| Starting a session — restore context           | `memo list --limit 20 --json`                         |
+| Normalize vocabulary before writing            | `memo tags list --sort frequency --json`              |
+| Before making a design choice                  | `memo search "<topic>" --json`                        |
+| Before touching a file you haven't seen before | `memo search "<filename or module name>" --json`      |
+| Evaluating whether to add a dependency         | `memo search "<library name>" --scope related --json` |
+| Onboarding to an unfamiliar repo               | `memo inspect --json` then `memo list --json`         |
+
+### Required Read Sequence
+
+At session start, run reads in this exact order:
+
+1. `memo setup validate`
+2. `memo list --limit 20 --json`
+3. `memo tags list --sort frequency --json`
+4. `memo search "<current issue/story/title>" --limit 10 --json`
+5. `memo search "<key contract or dependency>" --scope related --limit 5 --json` (when boundary impact is expected)
+
+Before coding or planning, synthesize findings in 4 bullets:
+
+- Constraints to preserve
+- Rejected alternatives to avoid
+- Contracts/boundaries that must remain stable
+- Sensitive files/modules to treat carefully
+
+---
+
+## Minimum Entry Schema
+
+All entries SHOULD include these fields when applicable:
+
+- Scope: issue/story identifier (`issue-<n>` or `story-<id>`)
+- Context: what changed and why now
+- Decision/Delivery: what was chosen or implemented
+- Impact: downstream behavior or contracts affected
+- Evidence: commit SHA and key files (`outcome` required)
+
+Additional requirements by purpose:
+
+- Intent entries MUST include constraints/non-goals and expected files.
+- Outcome entries MUST include AC coverage and quality gate status (`test`, `lint`, `format:check`, `typecheck`, `audit`).
+- Contract entries MUST include producer, consumer, validation rules, and failure behavior.
+
+---
+
+## Tag Taxonomy Standard
+
+Tags MUST be kebab-case and ordered in these layers:
+
+1. Domain tag (for example: `auth`, `tenant`, `ingestion`, `docs`)
+2. Work-item tag (`issue-113`, `story-s003`)
+3. Lifecycle tag (`intent`, `outcome`, `decision`, `contract`, `structure`)
+4. Impact/quality tag (`security`, `migration`, `gates-pass`, `docs-drift-fixed`)
+5. Optional boundary tag (`api`, `middleware`, `cross-repo`)
+
+Use 4-5 tags whenever possible. Reuse existing tags from `memo tags list`.
+
+---
+
+## Prerequisites
+
+### Environment Variables
+
+The following variables **MUST** be set before any `memo` command will work:
+
+| Variable              | Purpose                   | Example                 |
+| --------------------- | ------------------------- | ----------------------- |
+| `QDRANT_URL`          | Qdrant instance endpoint  | `http://localhost:6333` |
+| `QDRANT_API_KEY`      | API key (empty for local) | `""` or a cloud key     |
+| `EMBEDDINGS_PROVIDER` | Embedding backend         | `openai`                |
+| `EMBEDDINGS_API_KEY`  | Provider secret key       | `sk-...`                |
+
+> **Tip:** Store these in a `.env` file at the repository root. `memo-cli` loads it automatically via `dotenv`.
+
+### Repository Configuration
+
+A `memo.config.json` **MUST** exist at the repository root. Create one with:
+
+```bash
+memo setup init --repo <repo-name> --org <org-name> --domain <domain> [--relates-to repo1,repo2]
+```
+
+Verify it at any time:
+
+```bash
+memo setup validate   # exit 0 = valid
+memo setup show       # print effective config
+```
+
+---
+
+## Core Concepts
+
+### `repo` — Repository Identity
+
+`repo` is the **name of the codebase** this entry belongs to. It is set in `memo.config.json` and defaults into every `memo write` call automatically. Use the kebab-case name of the Git repository (e.g., `memo-cli`, `auth-service`, `api-gateway`).
+
+**Why it matters:** Every entry is scoped to a repo. `memo search` and `memo list` filter by your current repo by default, so entries from other repos don't pollute your results unless you explicitly request them with `--scope related`.
+
+**Rule:** Use the repo's canonical name — the one that appears in the GitHub URL. Don't abbreviate or alias it.
+
+---
+
+### `org` — Organization
+
+`org` is the **owner or organization** that the repository belongs to. In GitHub terms, this is the account or org username (e.g., `llipe`, `acme-corp`, `my-team`).
+
+**Why it matters:** `org` groups related repositories under a common owner. It enables cross-repo queries scoped to a single organization — e.g., finding all decisions made under `acme-corp` across all its services.
+
+**Rule:** Use the GitHub organization or user handle, kebab-case. All repos under the same team should share the same `org` value.
+
+---
+
+### `domain` — Product or Functional Area
+
+`domain` describes the **product area or functional concern** that this repository serves (e.g., `auth`, `payments`, `infra`, `ai`, `search`, `notifications`). It is broader than a repository — multiple repos can share the same domain.
+
+**Why it matters:** Domain is a cross-cutting label that lets you query decisions across all repos in a functional area. For example, all `auth`-domain decisions across `auth-service`, `api-gateway`, and `user-service` can be retrieved together.
+
+**How to choose:**
+
+- Use the business or technical capability, not the team name.
+- Keep it stable — domains change less often than repos.
+- Examples: `auth`, `billing`, `data-pipeline`, `mobile`, `platform`, `ai`, `infra`, `developer-tools`.
+
+---
+
+### `relates_to` — Connected Repositories
+
+`relates_to` is an **explicit list of other repository names** that this repo has a meaningful relationship with — shared contracts, shared schemas, upstream/downstream dependencies, or simply repos that an agent often works across together.
+
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
+
+**Why it matters:** Setting `relates_to` enables `--scope related` queries, which search entries across this repo **and** all listed repos simultaneously. This is how agents and developers get cross-service context without switching repositories.
+
+**When to add a repo to `relates_to`:**
+
+- This repo consumes an API or event contract that the other repo owns.
+- Decisions in the other repo often directly constrain decisions in this one.
+- You regularly need to cross-reference both repos during feature work.
+- They share a data model or schema.
+
+**Rule:** Keep `relates_to` intentional — list real dependencies, not every repo in the org. A bloated list degrades search signal.
+
+---
+
+### Entry Types
+
+| Type                | When to use                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `decision`          | Architectural or design choices ("We chose Postgres over Mongo because…") |
+| `integration_point` | Cross-service contracts, API boundaries, shared schemas                   |
+| `structure`         | Folder layout, module boundaries, naming conventions                      |
+
+### Source
+
+| Value    | Meaning                                                        |
+| -------- | -------------------------------------------------------------- |
+| `agent`  | Written by an AI agent (default when `defaults.source` is set) |
+| `manual` | Written by a human developer                                   |
+
+### Scoping
+
+Every entry belongs to a **repo**, **org**, and **domain** (all kebab-case). Queries default to the current repo context from `memo.config.json`.
+
+- `--scope repo` — Only entries for the current repository.
+- `--scope related` — Current repository + all repos listed in `relates_to`.
+
+---
+
+## Command Reference
+
+### `memo write` — Record a Decision
+
+```bash
+memo write \
+  --rationale "Chose JWT over session cookies for stateless auth across services" \
+  --tags "auth,jwt,stateless" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+**Required flags:**
+
+- `--rationale` — The decision text (1–5 000 chars).
+- `--tags` — 2–5 comma-separated kebab-case tags.
+
+**Optional flags:**
+
+- `--entry-type` — `decision` (default) | `integration_point` | `structure`
+- `--source` — `agent` | `manual` (falls back to config default)
+- `--commit` — Git commit SHA for traceability
+- `--story` — Story or task ID
+- `--files` — Comma-separated file paths touched by the decision
+- `--relates-to` — Related repo names
+- `--on-duplicate` — `consolidate` | `update` | `replace` | `create-new`
+- `--json` — Machine-readable output (**always use in agent mode**)
+
+**Duplicate handling:**
+When memo detects a duplicate (same `repo + commit + story + entry_type + source`), interactive mode prompts for resolution. In `--json` mode you **MUST** supply `--on-duplicate` or the command will fail.
+
+---
+
+### `memo search` — Semantic Search
+
+```bash
+memo search "rate limiting strategy" --limit 5 --json
+```
+
+Natural-language vector search over decision entries.
+
+**Optional flags:**
+
+- `--scope` — `repo` (default) | `related`
+- `--tags` — Comma-separated filter (AND logic)
+- `--entry-type` — Filter by type
+- `--source` — Filter by source
+- `--limit` — Max results (default 10)
+- `--json` — Machine-readable output
+
+---
+
+### `memo list` — Chronological Browse
+
+```bash
+memo list --limit 20 --json
+```
+
+Most-recent-first listing with optional date range.
+
+**Optional flags:**
+
+- `--scope`, `--tags`, `--entry-type`, `--source` — Same as search
+- `--from` / `--to` — ISO 8601 date boundaries
+- `--limit` — Max results (default 20)
+- `--json` — Machine-readable output
+
+---
+
+### `memo tags list` — Discover Tags
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Shows all unique tags with entry counts.
+
+**Optional flags:**
+
+- `--scope` — `repo` | `related`
+- `--sort` — `alpha` (default) | `frequency`
+- `--json` — Machine-readable output
+
+---
+
+### `memo inspect` — Global Facet Discovery
+
+```bash
+memo inspect --json
+```
+
+Lists all organizations, repositories, and domains across the entire knowledge base (ignores repo scope). Useful for onboarding and cross-team exploration.
+
+**Optional flags:**
+
+- `--orgs` / `--repos` / `--domains` — Show only one facet
+- `--json` — Machine-readable output
+
+---
+
+### `memo delete` — Remove Entries
+
+**Single entry:**
+
+```bash
+memo delete --id <uuid> --json
+```
+
+**Bulk (interactive only — blocked in `--json` mode for safety):**
+
+```bash
+memo delete --all-by-repo <repo-name> --yes
+memo delete --all-by-org <org-name> --yes
+```
+
+Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
+
+---
+
+## Agent Workflows
+
+### Starting a Session — Restore Context
+
+At the **beginning of every session**, run this sequence before writing a single line of code:
+
+```bash
+# 1. Confirm config is valid
+memo setup validate
+
+# 2. Discover what repos/orgs/domains exist
+memo inspect --json
+
+# 3. Review recent decisions for this repo
+memo list --limit 20 --json
+
+# 4. Check the established tag vocabulary
+memo tags list --sort frequency --json
+
+# 5. Search for context relevant to the current task
+memo search "<current task or feature description>" --limit 10 --json
+```
+
+Read the results before proceeding. Prior entries may contain constraints, preferred patterns, or rejected alternatives that directly affect how you should approach the current task.
+
+---
+
+### Recording Decisions — As You Work, Not Only at the End
+
+Write a memo entry **at the moment you make a decision**, not as a post-hoc summary. This preserves the full reasoning before context is lost.
+
+**Template:**
+
+```bash
+memo write \
+  --rationale "CONTEXT. DECISION. RATIONALE." \
+  --tags "tag1,tag2,tag3" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --story "ISSUE-42" \
+  --files "path/to/file1.ts,path/to/file2.ts" \
+  --json
+```
+
+The `--rationale` field is the most important field. See **Writing Quality** below.
+
+---
+
+### Recording File Changes — Explain the Why
+
+When modifying a significant file (entry point, core abstraction, schema, config), record what changed and why:
+
+```bash
+memo write \
+  --rationale "Modified src/lib/config.ts to add schema_version validation. The config loader previously accepted any object; adding Zod validation ensures CLI commands fail fast on malformed configs rather than producing silent errors downstream." \
+  --tags "config,validation,config-ts,error-handling" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --files "src/lib/config.ts,src/types/config.ts" \
+  --json
+```
+
+---
+
+### Recording Configuration Decisions
+
+Configuration decisions are especially important to preserve — they often appear opaque later with no obvious rationale in the code.
+
+```bash
+memo write \
+  --rationale "Set QDRANT_COLLECTION_NAME to 'decisions' permanently rather than making it configurable. A single collection per deployment simplifies queries and access control. Multi-tenancy is achieved via repo/org payload fields, not separate collections. Reconsidering this would require a data migration." \
+  --tags "qdrant,config,multi-tenancy,collection-design" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+Configuration decisions to always record:
+
+- Environment variable semantics (what the value controls, valid ranges, defaults)
+- Feature flags and their trigger conditions
+- Schema versions and migration policies
+- Storage layout choices (collection names, index strategies, partitioning)
+- Security-related configuration (TLS, auth, CORS, rate limits)
+
+---
+
+### Intent Entry — Narrate Before Acting
+
+For significant tasks, write an **intent entry** before starting implementation. This creates a checkpoint that future sessions can find, and anchors the rationale for every decision that follows.
+
+```bash
+memo write \
+  --rationale "Starting implementation of story ISSUE-37: safe delete command. Approach: add a --yes flag for non-interactive confirmation, block --json with bulk delete flags (safety guard for agents), preview affected entries before deletion. No soft-delete; permanent removal via Qdrant point deletion. This matches the existing write/search command pattern." \
+  --tags "delete,safety,issue-37,intent" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --json
+```
+
+---
+
+### Outcome Entry — Summarize After Completing
+
+When finishing a task, write an **outcome entry** that captures what actually happened vs. what was intended:
+
+```bash
+memo write \
+  --rationale "Completed ISSUE-37 safe delete command. Shipped: --id single delete, --all-by-repo and --all-by-org bulk delete (interactive only), --yes to skip confirm, preview before deletion. Deviation from intent: bulk delete also disallowed with --json (not just flagged) after discovering Qdrant batch delete has no confirmation step. Modified: src/commands/delete.ts (new), tests/unit/commands/delete.test.ts (new)." \
+  --tags "delete,safety,issue-37,outcome" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --files "src/commands/delete.ts,tests/unit/commands/delete.test.ts" \
+  --json
+```
+
+---
+
+## Writing Quality
+
+The `--rationale` field must be **precise enough that a different developer or agent — with no prior context — can understand what was decided, why, and what it affects.** A good entry answers three questions:
+
+1. **Context** — What is the situation, constraint, or problem?
+2. **Decision** — What was chosen or done?
+3. **Rationale** — Why this choice over the alternatives?
+
+### Good vs. Bad Examples
+
+**Too vague — useless to a future reader:**
+
+> "Updated auth to use JWT."
+
+**Precise — useful across sessions and developers:**
+
+> "Switched authentication from server-side sessions to JWT (HS256, 15-min access + 7-day refresh). Sessions required sticky routing which is incompatible with the planned horizontal scaling. JWTs are stateless — any instance can validate without a shared session store. Trade-off: revocation requires a Redis blacklist (added to ISSUE-51 backlog). Files: src/auth/jwt.ts, src/middleware/auth.ts."
+
+---
+
+**Too vague:**
+
+> "Changed config validation."
+
+**Precise:**
+
+> "Added Zod validation to memo.config.json loader (src/lib/config.ts). Previously the code trusted the file's shape; malformed configs caused cryptic runtime errors deep in Qdrant queries. Now the CLI fails immediately at startup with a structured error message. This is the single place config is read — no other validation needed."
+
+---
+
+**Too vague:**
+
+> "Used Redis for caching."
+
+**Precise:**
+
+> "Chose Redis (via ioredis) over in-process LRU cache for rate-limit counters. In-process cache doesn't survive pod restarts and is not shared across replicas. Redis TTL natively aligns with the sliding window algorithm. Accepted dependency: Redis must be available in all environments. Config: REDIS_URL env var, no auth in dev, TLS required in prod."
+
+---
+
+### Structural Rule
+
+Write `--rationale` as a single coherent paragraph (or 2-3 short sentences). **Avoid bullet points** in the rationale field — they fragment reasoning and lose connective logic. Save structure for tags.
+
+Minimum viable rationale: **context sentence + decision sentence + why sentence**.
+
+---
+
+## Tag Strategy
+
+Tags are the primary way to discover entries. Good tagging makes the difference between a searchable knowledge base and an unsearchable archive.
+
+### Tag Layers
+
+Apply tags across **multiple layers** simultaneously:
+
+| Layer              | Purpose                 | Examples                                               |
+| ------------------ | ----------------------- | ------------------------------------------------------ |
+| **Domain/feature** | What area of the system | `auth`, `rate-limiting`, `config`, `delete`, `storage` |
+| **Technology**     | What tech is involved   | `qdrant`, `redis`, `openai`, `zod`, `jwt`              |
+| **Entry nature**   | What kind of change     | `intent`, `outcome`, `constraint`, `trade-off`, `adr`  |
+| **Story/task ref** | Traceability            | `issue-37`, `story-s003`, `prd-001`                    |
+| **Scope**          | How broad the impact    | `cross-repo`, `breaking-change`, `config-change`       |
+
+Every write SHOULD include tags from at least **2–3 layers**.
+
+### Before Inventing a Tag — Check What Exists
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Re-use existing tags whenever possible. Consistent vocabulary is what allows `memo search` to surface related entries from weeks ago or from a different repository.
+
+### Tag Naming Rules
+
+- Kebab-case only: `rate-limiting`, not `rateLimiting` or `rate_limiting`.
+- Prefer specific over generic: `qdrant-collection` over `database`.
+- For story/task refs: `issue-37`, `story-s003` (numeric, no spaces).
+- Session markers: `intent` (beginning of task) and `outcome` (completion).
+- For cross-cutting concerns: `breaking-change`, `security`, `performance`, `config-change`.
+
+### Tag Examples by Scenario
+
+**Architectural decision on storage:**
+
+```
+qdrant,collection-design,multi-tenancy,decision,adr
+```
+
+**Config change:**
+
+```
+config,env-vars,config-change,issue-42
+```
+
+**Integration contract between two services:**
+
+```
+api-contract,auth-service,cross-repo,integration-point,breaking-change
+```
+
+**Starting a new feature (intent):**
+
+```
+delete-command,safety,issue-37,intent
+```
+
+**Completing a feature (outcome):**
+
+```
+delete-command,safety,issue-37,outcome
+```
+
+**Performance trade-off:**
+
+```
+embeddings,openai,performance,trade-off,caching
+```
+
+---
+
+## Multi-Developer & Cross-Session Context
+
+`memo-cli` is designed so that **every agent and every developer shares the same decision history**. This is what enables continuity across days, team rotations, and parallel workstreams.
+
+### Shared Knowledge Base
+
+All entries are stored in a shared Qdrant instance. When Developer A (or Agent A) records a decision, Developer B can immediately find it via `memo search`. There is no per-user silo.
+
+### Cross-Repository Visibility
+
+Use `--scope related` to query across connected repositories:
+
+```bash
+memo search "auth contract" --scope related --json
+```
+
+This is critical for:
+
+- Microservice architectures where contracts span repos.
+- Agent workflows that touch multiple repositories in sequence.
+- Detecting when a decision in one repo contradicts a constraint in another.
+
+Configure related repos in `memo.config.json`:
+
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
+
+### Session Continuity for Agents
+
+Agents are stateless between sessions. To maintain continuity:
+
+1. **Start every session** with `memo list` and `memo search` — always.
+2. **Write an intent entry** before starting significant work.
+3. **Write as you decide**, not as a batch at the end.
+4. **Write an outcome entry** when completing a task, including any deviations from intent.
+5. **Tag consistently** — check `memo tags list` before picking tags.
+
+### Multi-Day Work Pattern
+
+For work that spans multiple days:
+
+- **Day 1 end**: Write an outcome entry with current state, what's done, what's next, any open questions.
+- **Day 2 start**: `memo search "<task name or issue number>" --json` to restore exact context.
+- The tags `intent` and `outcome` combined with a story tag (e.g., `issue-37`) make the full arc of a feature retrievable as a timeline.
+
+### What to Record vs. What to Skip
+
+| Record                                        | Skip                                                        |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| Architectural choices and their rationale     | Trivial implementation details (variable names, formatting) |
+| Technology selections with trade-off analysis | Routine bug fixes with no design impact                     |
+| Configuration changes that affect behavior    | Code style choices (use linters)                            |
+| API contracts and integration boundaries      | Dependency version bumps (use lockfile)                     |
+| Security-sensitive design choices             | Temporary workarounds expected to be removed within hours   |
+| Performance trade-offs and their context      | Generated code                                              |
+| Rejected alternatives and why                 | CI/build configuration (use config files)                   |
+| Constraints discovered during implementation  | Debugging steps                                             |
+
+---
+
+## Memory Scopes (IDE / Agent Memory vs. memo-cli)
+
+Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each prevents both redundancy and gaps.
+
+| Scope                 | Where                  | Persistence                                    | Use For                                                                                     |
+| --------------------- | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **User memory**       | `/memories/`           | All workspaces, all sessions                   | Personal preferences, debugging patterns, general agent insights                            |
+| **Session memory**    | `/memories/session/`   | Current conversation only                      | Scratch notes, in-progress state, temporary checklists                                      |
+| **Repository memory** | `/memories/repo/`      | Current workspace                              | Repo gotchas, build commands, local conventions — fast-access notes for this repo           |
+| **memo-cli**          | Qdrant (shared remote) | Permanent, shared across all people and agents | Architectural decisions, integration contracts, structural choices, configuration rationale |
+
+### Decision Tree: Where Does This Information Belong?
+
+```
+Is it a decision, rationale, constraint, contract, or config choice?
+  └─ YES → memo write  (it belongs to the shared knowledge base)
+
+Is it a repo-specific gotcha or quick operational fact?
+  └─ YES → /memories/repo/ (and also memo write if it reflects a real design choice)
+
+Is it a personal preference or general agent pattern?
+  └─ YES → /memories/ (user memory)
+
+Is it temporary context that only matters for the current session?
+  └─ YES → /memories/session/
+```
+
+**Key principle:** If the information would help a _different_ developer or agent working in the same codebase — even a year from now — it belongs in `memo-cli`.
+
+---
+
+## Safe Operation Guardrails
+
+### Non-Destructive Defaults
+
+- `memo delete` requires confirmation by default. Use `--yes` to skip only when you are certain.
+- Bulk delete (`--all-by-repo`, `--all-by-org`) is **blocked in `--json` mode** as a safety guard against accidental mass deletion by agents.
+- `memo write` detects duplicates and prompts for resolution rather than silently overwriting.
+
+### Agent Mode (`--json`)
+
+Agents **SHOULD** always pass `--json` for predictable, parseable output. Key behaviors in JSON mode:
+
+- All output is structured JSON on stdout.
+- Errors produce JSON error objects to stderr.
+- Interactive prompts are suppressed — flags must supply all decisions.
+- `--on-duplicate` is required when a duplicate is detected.
+- Bulk delete is prohibited.
+
+### Validation Before Writing
+
+Before `memo write`, agents SHOULD:
+
+1. Verify `memo setup validate` passes.
+2. Confirm tags are kebab-case (lowercase, hyphens only).
+3. Ensure rationale is meaningful (not placeholder text).
+4. Check for duplicates with `memo search` first.
+
+### Error Handling
+
+All `memo` commands exit with:
+
+- **0** — Success
+- **1** — Validation or user error (bad flags, invalid config)
+- **2** — Unexpected/infrastructure error (Qdrant down, embedding API failure)
+
+When a command fails:
+
+1. Read the error code and message from stderr.
+2. For exit code 1: fix the input and retry.
+3. For exit code 2: check connectivity (`QDRANT_URL`) and API keys before retrying.
+
+### Environment Variable Safety
+
+- **Never** log or output `EMBEDDINGS_API_KEY` or `QDRANT_API_KEY`.
+- Store credentials in `.env` (which should be in `.gitignore`).
+- For CI/CD, use secrets management rather than plaintext config.
+
+---
+
+## Quick Reference Card
+
+```
+memo setup init --repo <r> --org <o> --domain <d>   # Initialize config
+memo setup validate                                   # Verify config
+memo setup show [--json]                              # Display config
+
+memo write --rationale "..." --tags "a,b,c" [--json]  # Record decision
+memo search "query" [--scope related] [--json]         # Semantic search
+memo list [--from DATE] [--to DATE] [--json]           # Browse entries
+memo tags list [--sort frequency] [--json]             # Discover tags
+memo inspect [--json]                                  # Global facets
+memo delete --id <uuid> [--json]                       # Delete entry
+```
+
+---
+
+## Installation in Another Repository
+
+1. **Copy** the `memo-cli-usage/` folder into `<your-repo>/.github/skills/`.
+2. **Add** the skill to your agent/skill registry (e.g., `AGENTS.md`):
+   ```markdown
+   | memo-cli-usage | `.github/skills/memo-cli-usage/` | Agent guidance for memo-cli operations | Any agent |
+   ```
+3. **Install** `memo-cli` as a dev dependency:
+   ```bash
+   pnpm add -D memo-cli   # or npm install -D memo-cli
+   ```
+4. **Configure** the repository:
+   ```bash
+   npx memo setup init --repo <name> --org <org> --domain <domain>
+   ```
+5. **Set** environment variables (`.env` or CI secrets):
+   ```
+   QDRANT_URL=http://localhost:6333
+   QDRANT_API_KEY=
+   EMBEDDINGS_PROVIDER=openai
+   EMBEDDINGS_API_KEY=sk-...
+   ```
+6. The skill is now active — any agent that loads it will know how to use `memo-cli`.

--- a/.github/skills/memo-cli-usage/SKILL.md
+++ b/.github/skills/memo-cli-usage/SKILL.md
@@ -1,95 +1,36 @@
-# memo-cli Usage Skill
+---
+name: memo-cli-usage
+description: "Read and write architectural decisions to the shared memo-cli knowledge base. Use when recording or restoring cross-session context."
+---
 
-Teach AI agents (and human developers) how to operate **memo-cli** — the agent-first CLI for capturing and querying architectural decisions stored in a shared Qdrant vector database.
+# memo-cli Usage — Quick Reference
 
-Use this skill whenever an agent needs to **read**, **write**, **search**, or **manage** decision entries in a repository that has `memo-cli` installed.
-
-> **Portability:** This skill is self-contained. Copy the `memo-cli-usage/` folder into any repository's `.github/skills/` directory and reference it from that repo's `AGENTS.md` or skill registry.
+Operate `memo-cli` for reading and writing architectural decisions in a shared Qdrant vector database. For full CLI documentation (all flags, configuration, admin operations, schema details), see [`REFERENCE.md`](./REFERENCE.md).
 
 ---
 
-## Purpose
+## Setup Validation
 
-`memo-cli` is the **shared memory** that keeps agents coherent across time, sessions, and projects. It is not a log. It is not a changelog. It is a curated, searchable record of the decisions that shaped the codebase — written with enough precision that anyone (human or agent) arriving days, weeks, or months later can understand **what was decided, why, and what it affected**.
+```bash
+memo setup validate   # exit 0 = configured correctly
+```
 
-An agent that uses `memo-cli` well:
-
-- Narrates its reasoning as it acts, not only at the end.
-- Records the files it modifies and why those files were the right place.
-- Explains configuration and architectural choices so future agents don't re-derive them.
-- Tags entries consistently so discovery remains reliable across projects.
-
-### Success Outcomes
-
-Using memo-cli correctly SHOULD produce these outcomes:
-
-- Faster planning and implementation by reusing prior constraints and decisions.
-- Consistent execution across agents and sessions.
-- Auditable traceability from decision to issue/story, files, and commit evidence.
-- Better cross-repo contract safety when `--scope related` is used intentionally.
+If validation fails, run: `memo setup init --repo <repo> --org <org> --domain <domain>`
 
 ---
 
-## Entry Purposes and Scope
+## Session Start — Restore Context
 
-Every write MUST have one clear purpose. Do not combine multiple purposes into one long entry.
+Run before writing any code:
 
-| Purpose                    | What it captures                                     | Entry Type          | Required lifecycle tag |
-| -------------------------- | ---------------------------------------------------- | ------------------- | ---------------------- |
-| Intent                     | Planned approach, constraints, expected impact       | `decision`          | `intent`               |
-| Outcome                    | Delivered behavior and validation evidence           | `decision`          | `outcome`              |
-| Durable architecture       | Long-lived technical decisions and trade-offs        | `decision`          | `decision`             |
-| Integration contract       | Cross-boundary assumptions and compatibility details | `integration_point` | `contract`             |
-| Structural convention      | Module boundaries and naming/layout rules            | `structure`         | `structure`            |
+```bash
+memo list --limit 20 --json
+memo tags list --sort frequency --json
+memo search "<current task description>" --limit 10 --json
+memo search "<key contract or dependency>" --scope related --limit 5 --json
+```
 
-Write only reusable knowledge. Do not write routine activity noise that is already obvious from a diff.
-
----
-
-## When to Write to memo-cli
-
-Write a memo entry **during** or **immediately after** any of these moments:
-
-| Trigger                                                                    | Entry Type               |
-| -------------------------------------------------------------------------- | ------------------------ |
-| Choosing a library, framework, or service                                  | `decision`               |
-| Choosing how to structure a module or data model                           | `decision` / `structure` |
-| Changing a config file and explaining why                                  | `decision`               |
-| Identifying or formalizing a cross-service contract                        | `integration_point`      |
-| Modifying critical files (entry points, core abstractions, schema)         | `decision`               |
-| Discovering a constraint (API limit, platform quirk, security requirement) | `decision`               |
-| Resolving a conflict between two approaches                                | `decision`               |
-| Establishing a naming or layout convention                                 | `structure`              |
-| Starting work on a story or task (intent entry)                            | `decision`               |
-| Completing a story or task (outcome entry)                                 | `decision`               |
-
----
-
-## When to Search memo-cli
-
-Search **before** taking action, not only when stuck:
-
-| Situation                                      | Command                                               |
-| ---------------------------------------------- | ----------------------------------------------------- |
-| Starting a session — restore context           | `memo list --limit 20 --json`                         |
-| Normalize vocabulary before writing            | `memo tags list --sort frequency --json`              |
-| Before making a design choice                  | `memo search "<topic>" --json`                        |
-| Before touching a file you haven't seen before | `memo search "<filename or module name>" --json`      |
-| Evaluating whether to add a dependency         | `memo search "<library name>" --scope related --json` |
-| Onboarding to an unfamiliar repo               | `memo inspect --json` then `memo list --json`         |
-
-### Required Read Sequence
-
-At session start, run reads in this exact order:
-
-1. `memo setup validate`
-2. `memo list --limit 20 --json`
-3. `memo tags list --sort frequency --json`
-4. `memo search "<current issue/story/title>" --limit 10 --json`
-5. `memo search "<key contract or dependency>" --scope related --limit 5 --json` (when boundary impact is expected)
-
-Before coding or planning, synthesize findings in 4 bullets:
-
+Synthesize findings into:
 - Constraints to preserve
 - Rejected alternatives to avoid
 - Contracts/boundaries that must remain stable
@@ -97,697 +38,106 @@ Before coding or planning, synthesize findings in 4 bullets:
 
 ---
 
-## Minimum Entry Schema
+## Writing Entries
 
-All entries SHOULD include these fields when applicable:
-
-- Scope: issue/story identifier (`issue-<n>` or `story-<id>`)
-- Context: what changed and why now
-- Decision/Delivery: what was chosen or implemented
-- Impact: downstream behavior or contracts affected
-- Evidence: commit SHA and key files (`outcome` required)
-
-Additional requirements by purpose:
-
-- Intent entries MUST include constraints/non-goals and expected files.
-- Outcome entries MUST include AC coverage and quality gate status (`test`, `lint`, `format:check`, `typecheck`, `audit`).
-- Contract entries MUST include producer, consumer, validation rules, and failure behavior.
-
----
-
-## Tag Taxonomy Standard
-
-Tags MUST be kebab-case and ordered in these layers:
-
-1. Domain tag (for example: `auth`, `tenant`, `ingestion`, `docs`)
-2. Work-item tag (`issue-113`, `story-s003`)
-3. Lifecycle tag (`intent`, `outcome`, `decision`, `contract`, `structure`)
-4. Impact/quality tag (`security`, `migration`, `gates-pass`, `docs-drift-fixed`)
-5. Optional boundary tag (`api`, `middleware`, `cross-repo`)
-
-Use 4-5 tags whenever possible. Reuse existing tags from `memo tags list`.
-
----
-
-## Prerequisites
-
-### Environment Variables
-
-The following variables **MUST** be set before any `memo` command will work:
-
-| Variable              | Purpose                   | Example                 |
-| --------------------- | ------------------------- | ----------------------- |
-| `QDRANT_URL`          | Qdrant instance endpoint  | `http://localhost:6333` |
-| `QDRANT_API_KEY`      | API key (empty for local) | `""` or a cloud key     |
-| `EMBEDDINGS_PROVIDER` | Embedding backend         | `openai`                |
-| `EMBEDDINGS_API_KEY`  | Provider secret key       | `sk-...`                |
-
-> **Tip:** Store these in a `.env` file at the repository root. `memo-cli` loads it automatically via `dotenv`.
-
-### Repository Configuration
-
-A `memo.config.json` **MUST** exist at the repository root. Create one with:
-
-```bash
-memo setup init --repo <repo-name> --org <org-name> --domain <domain> [--relates-to repo1,repo2]
-```
-
-Verify it at any time:
-
-```bash
-memo setup validate   # exit 0 = valid
-memo setup show       # print effective config
-```
-
----
-
-## Core Concepts
-
-### `repo` — Repository Identity
-
-`repo` is the **name of the codebase** this entry belongs to. It is set in `memo.config.json` and defaults into every `memo write` call automatically. Use the kebab-case name of the Git repository (e.g., `memo-cli`, `auth-service`, `api-gateway`).
-
-**Why it matters:** Every entry is scoped to a repo. `memo search` and `memo list` filter by your current repo by default, so entries from other repos don't pollute your results unless you explicitly request them with `--scope related`.
-
-**Rule:** Use the repo's canonical name — the one that appears in the GitHub URL. Don't abbreviate or alias it.
-
----
-
-### `org` — Organization
-
-`org` is the **owner or organization** that the repository belongs to. In GitHub terms, this is the account or org username (e.g., `llipe`, `acme-corp`, `my-team`).
-
-**Why it matters:** `org` groups related repositories under a common owner. It enables cross-repo queries scoped to a single organization — e.g., finding all decisions made under `acme-corp` across all its services.
-
-**Rule:** Use the GitHub organization or user handle, kebab-case. All repos under the same team should share the same `org` value.
-
----
-
-### `domain` — Product or Functional Area
-
-`domain` describes the **product area or functional concern** that this repository serves (e.g., `auth`, `payments`, `infra`, `ai`, `search`, `notifications`). It is broader than a repository — multiple repos can share the same domain.
-
-**Why it matters:** Domain is a cross-cutting label that lets you query decisions across all repos in a functional area. For example, all `auth`-domain decisions across `auth-service`, `api-gateway`, and `user-service` can be retrieved together.
-
-**How to choose:**
-
-- Use the business or technical capability, not the team name.
-- Keep it stable — domains change less often than repos.
-- Examples: `auth`, `billing`, `data-pipeline`, `mobile`, `platform`, `ai`, `infra`, `developer-tools`.
-
----
-
-### `relates_to` — Connected Repositories
-
-`relates_to` is an **explicit list of other repository names** that this repo has a meaningful relationship with — shared contracts, shared schemas, upstream/downstream dependencies, or simply repos that an agent often works across together.
-
-```json
-{
-  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
-}
-```
-
-**Why it matters:** Setting `relates_to` enables `--scope related` queries, which search entries across this repo **and** all listed repos simultaneously. This is how agents and developers get cross-service context without switching repositories.
-
-**When to add a repo to `relates_to`:**
-
-- This repo consumes an API or event contract that the other repo owns.
-- Decisions in the other repo often directly constrain decisions in this one.
-- You regularly need to cross-reference both repos during feature work.
-- They share a data model or schema.
-
-**Rule:** Keep `relates_to` intentional — list real dependencies, not every repo in the org. A bloated list degrades search signal.
-
----
-
-### Entry Types
-
-| Type                | When to use                                                               |
-| ------------------- | ------------------------------------------------------------------------- |
-| `decision`          | Architectural or design choices ("We chose Postgres over Mongo because…") |
-| `integration_point` | Cross-service contracts, API boundaries, shared schemas                   |
-| `structure`         | Folder layout, module boundaries, naming conventions                      |
-
-### Source
-
-| Value    | Meaning                                                        |
-| -------- | -------------------------------------------------------------- |
-| `agent`  | Written by an AI agent (default when `defaults.source` is set) |
-| `manual` | Written by a human developer                                   |
-
-### Scoping
-
-Every entry belongs to a **repo**, **org**, and **domain** (all kebab-case). Queries default to the current repo context from `memo.config.json`.
-
-- `--scope repo` — Only entries for the current repository.
-- `--scope related` — Current repository + all repos listed in `relates_to`.
-
----
-
-## Command Reference
-
-### `memo write` — Record a Decision
+### Intent Entry (before starting a story/task)
 
 ```bash
 memo write \
-  --rationale "Chose JWT over session cookies for stateless auth across services" \
-  --tags "auth,jwt,stateless" \
+  --rationale "Context: Starting ISSUE-<##> because <trigger>. Decision: implement via <approach>, preserving <constraints>. Impact: affects <modules/contracts>." \
+  --tags "<domain>,issue-<number>,intent,<impact-tag>" \
   --entry-type decision \
   --source agent \
+  --story "ISSUE-<number>" \
+  --on-duplicate consolidate \
   --json
 ```
 
-**Required flags:**
-
-- `--rationale` — The decision text (1–5 000 chars).
-- `--tags` — 2–5 comma-separated kebab-case tags.
-
-**Optional flags:**
-
-- `--entry-type` — `decision` (default) | `integration_point` | `structure`
-- `--source` — `agent` | `manual` (falls back to config default)
-- `--commit` — Git commit SHA for traceability
-- `--story` — Story or task ID
-- `--files` — Comma-separated file paths touched by the decision
-- `--relates-to` — Related repo names
-- `--on-duplicate` — `consolidate` | `update` | `replace` | `create-new`
-- `--json` — Machine-readable output (**always use in agent mode**)
-
-**Duplicate handling:**
-When memo detects a duplicate (same `repo + commit + story + entry_type + source`), interactive mode prompts for resolution. In `--json` mode you **MUST** supply `--on-duplicate` or the command will fail.
-
----
-
-### `memo search` — Semantic Search
-
-```bash
-memo search "rate limiting strategy" --limit 5 --json
-```
-
-Natural-language vector search over decision entries.
-
-**Optional flags:**
-
-- `--scope` — `repo` (default) | `related`
-- `--tags` — Comma-separated filter (AND logic)
-- `--entry-type` — Filter by type
-- `--source` — Filter by source
-- `--limit` — Max results (default 10)
-- `--json` — Machine-readable output
-
----
-
-### `memo list` — Chronological Browse
-
-```bash
-memo list --limit 20 --json
-```
-
-Most-recent-first listing with optional date range.
-
-**Optional flags:**
-
-- `--scope`, `--tags`, `--entry-type`, `--source` — Same as search
-- `--from` / `--to` — ISO 8601 date boundaries
-- `--limit` — Max results (default 20)
-- `--json` — Machine-readable output
-
----
-
-### `memo tags list` — Discover Tags
-
-```bash
-memo tags list --sort frequency --json
-```
-
-Shows all unique tags with entry counts.
-
-**Optional flags:**
-
-- `--scope` — `repo` | `related`
-- `--sort` — `alpha` (default) | `frequency`
-- `--json` — Machine-readable output
-
----
-
-### `memo inspect` — Global Facet Discovery
-
-```bash
-memo inspect --json
-```
-
-Lists all organizations, repositories, and domains across the entire knowledge base (ignores repo scope). Useful for onboarding and cross-team exploration.
-
-**Optional flags:**
-
-- `--orgs` / `--repos` / `--domains` — Show only one facet
-- `--json` — Machine-readable output
-
----
-
-### `memo delete` — Remove Entries
-
-**Single entry:**
-
-```bash
-memo delete --id <uuid> --json
-```
-
-**Bulk (interactive only — blocked in `--json` mode for safety):**
-
-```bash
-memo delete --all-by-repo <repo-name> --yes
-memo delete --all-by-org <org-name> --yes
-```
-
-Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
-
----
-
-## Agent Workflows
-
-### Starting a Session — Restore Context
-
-At the **beginning of every session**, run this sequence before writing a single line of code:
-
-```bash
-# 1. Confirm config is valid
-memo setup validate
-
-# 2. Discover what repos/orgs/domains exist
-memo inspect --json
-
-# 3. Review recent decisions for this repo
-memo list --limit 20 --json
-
-# 4. Check the established tag vocabulary
-memo tags list --sort frequency --json
-
-# 5. Search for context relevant to the current task
-memo search "<current task or feature description>" --limit 10 --json
-```
-
-Read the results before proceeding. Prior entries may contain constraints, preferred patterns, or rejected alternatives that directly affect how you should approach the current task.
-
----
-
-### Recording Decisions — As You Work, Not Only at the End
-
-Write a memo entry **at the moment you make a decision**, not as a post-hoc summary. This preserves the full reasoning before context is lost.
-
-**Template:**
+### Outcome Entry (after completing a story/task)
 
 ```bash
 memo write \
-  --rationale "CONTEXT. DECISION. RATIONALE." \
-  --tags "tag1,tag2,tag3" \
+  --rationale "Context: Completed ISSUE-<##>. Delivery: shipped <behavior>, deviations <none|details>, AC <x/y> verified. Impact: quality gates test=<p/f>; lint=<p/f>; format:check=<p/f>; typecheck=<p/f>; audit=<p/f>." \
+  --tags "<domain>,issue-<number>,outcome,gates-pass" \
   --entry-type decision \
   --source agent \
   --commit "$(git rev-parse HEAD)" \
-  --story "ISSUE-42" \
-  --files "path/to/file1.ts,path/to/file2.ts" \
+  --story "ISSUE-<number>" \
+  --files "<key files modified>" \
+  --on-duplicate consolidate \
   --json
 ```
 
-The `--rationale` field is the most important field. See **Writing Quality** below.
-
----
-
-### Recording File Changes — Explain the Why
-
-When modifying a significant file (entry point, core abstraction, schema, config), record what changed and why:
+### Decision Entry (architectural choices)
 
 ```bash
 memo write \
-  --rationale "Modified src/lib/config.ts to add schema_version validation. The config loader previously accepted any object; adding Zod validation ensures CLI commands fail fast on malformed configs rather than producing silent errors downstream." \
-  --tags "config,validation,config-ts,error-handling" \
-  --entry-type decision \
-  --source agent \
-  --commit "$(git rev-parse HEAD)" \
-  --files "src/lib/config.ts,src/types/config.ts" \
-  --json
-```
-
----
-
-### Recording Configuration Decisions
-
-Configuration decisions are especially important to preserve — they often appear opaque later with no obvious rationale in the code.
-
-```bash
-memo write \
-  --rationale "Set QDRANT_COLLECTION_NAME to 'decisions' permanently rather than making it configurable. A single collection per deployment simplifies queries and access control. Multi-tenancy is achieved via repo/org payload fields, not separate collections. Reconsidering this would require a data migration." \
-  --tags "qdrant,config,multi-tenancy,collection-design" \
+  --rationale "Context: <situation>. Decision: <what was chosen>. Rationale: <why this over alternatives>." \
+  --tags "<domain>,<technology>,decision" \
   --entry-type decision \
   --source agent \
   --json
 ```
 
-Configuration decisions to always record:
+---
 
-- Environment variable semantics (what the value controls, valid ranges, defaults)
-- Feature flags and their trigger conditions
-- Schema versions and migration policies
-- Storage layout choices (collection names, index strategies, partitioning)
-- Security-related configuration (TLS, auth, CORS, rate limits)
+## Entry Types
+
+| Type | Use For |
+|------|---------|
+| `decision` | Architectural/design choices, intent, outcome |
+| `integration_point` | Cross-service contracts, API boundaries |
+| `structure` | Module layout, naming conventions |
 
 ---
 
-### Intent Entry — Narrate Before Acting
+## Tag Rules
 
-For significant tasks, write an **intent entry** before starting implementation. This creates a checkpoint that future sessions can find, and anchors the rationale for every decision that follows.
-
-```bash
-memo write \
-  --rationale "Starting implementation of story ISSUE-37: safe delete command. Approach: add a --yes flag for non-interactive confirmation, block --json with bulk delete flags (safety guard for agents), preview affected entries before deletion. No soft-delete; permanent removal via Qdrant point deletion. This matches the existing write/search command pattern." \
-  --tags "delete,safety,issue-37,intent" \
-  --entry-type decision \
-  --source agent \
-  --story "ISSUE-37" \
-  --json
-```
+- Kebab-case only: `rate-limiting` not `rateLimiting`
+- 4-5 tags per entry across layers: domain, work-item, lifecycle, impact, boundary
+- Check existing tags first: `memo tags list --sort frequency --json`
+- Reuse over inventing new tags
 
 ---
 
-### Outcome Entry — Summarize After Completing
+## When to Write
 
-When finishing a task, write an **outcome entry** that captures what actually happened vs. what was intended:
-
-```bash
-memo write \
-  --rationale "Completed ISSUE-37 safe delete command. Shipped: --id single delete, --all-by-repo and --all-by-org bulk delete (interactive only), --yes to skip confirm, preview before deletion. Deviation from intent: bulk delete also disallowed with --json (not just flagged) after discovering Qdrant batch delete has no confirmation step. Modified: src/commands/delete.ts (new), tests/unit/commands/delete.test.ts (new)." \
-  --tags "delete,safety,issue-37,outcome" \
-  --entry-type decision \
-  --source agent \
-  --story "ISSUE-37" \
-  --files "src/commands/delete.ts,tests/unit/commands/delete.test.ts" \
-  --json
-```
+- Choosing a library, framework, or architecture pattern
+- Changing config files (explain why)
+- Modifying core abstractions, schemas, entry points
+- Establishing naming/layout conventions
+- Discovering constraints (API limits, platform quirks)
+- Starting/completing a story (intent/outcome)
 
 ---
 
-## Writing Quality
+## When to Search
 
-The `--rationale` field must be **precise enough that a different developer or agent — with no prior context — can understand what was decided, why, and what it affects.** A good entry answers three questions:
-
-1. **Context** — What is the situation, constraint, or problem?
-2. **Decision** — What was chosen or done?
-3. **Rationale** — Why this choice over the alternatives?
-
-### Good vs. Bad Examples
-
-**Too vague — useless to a future reader:**
-
-> "Updated auth to use JWT."
-
-**Precise — useful across sessions and developers:**
-
-> "Switched authentication from server-side sessions to JWT (HS256, 15-min access + 7-day refresh). Sessions required sticky routing which is incompatible with the planned horizontal scaling. JWTs are stateless — any instance can validate without a shared session store. Trade-off: revocation requires a Redis blacklist (added to ISSUE-51 backlog). Files: src/auth/jwt.ts, src/middleware/auth.ts."
+- Before making design choices: `memo search "<topic>" --json`
+- Before touching unfamiliar files: `memo search "<filename>" --json`
+- Cross-repo context: `memo search "<query>" --scope related --json`
 
 ---
 
-**Too vague:**
+## Agent Mode Rules
 
-> "Changed config validation."
-
-**Precise:**
-
-> "Added Zod validation to memo.config.json loader (src/lib/config.ts). Previously the code trusted the file's shape; malformed configs caused cryptic runtime errors deep in Qdrant queries. Now the CLI fails immediately at startup with a structured error message. This is the single place config is read — no other validation needed."
-
----
-
-**Too vague:**
-
-> "Used Redis for caching."
-
-**Precise:**
-
-> "Chose Redis (via ioredis) over in-process LRU cache for rate-limit counters. In-process cache doesn't survive pod restarts and is not shared across replicas. Redis TTL natively aligns with the sliding window algorithm. Accepted dependency: Redis must be available in all environments. Config: REDIS_URL env var, no auth in dev, TLS required in prod."
+- Always pass `--json` for parseable output
+- Always pass `--on-duplicate consolidate` for writes
+- Never log API keys or secrets
+- Bulk delete is blocked in `--json` mode (safety guard)
 
 ---
 
-### Structural Rule
-
-Write `--rationale` as a single coherent paragraph (or 2-3 short sentences). **Avoid bullet points** in the rationale field — they fragment reasoning and lose connective logic. Save structure for tags.
-
-Minimum viable rationale: **context sentence + decision sentence + why sentence**.
-
----
-
-## Tag Strategy
-
-Tags are the primary way to discover entries. Good tagging makes the difference between a searchable knowledge base and an unsearchable archive.
-
-### Tag Layers
-
-Apply tags across **multiple layers** simultaneously:
-
-| Layer              | Purpose                 | Examples                                               |
-| ------------------ | ----------------------- | ------------------------------------------------------ |
-| **Domain/feature** | What area of the system | `auth`, `rate-limiting`, `config`, `delete`, `storage` |
-| **Technology**     | What tech is involved   | `qdrant`, `redis`, `openai`, `zod`, `jwt`              |
-| **Entry nature**   | What kind of change     | `intent`, `outcome`, `constraint`, `trade-off`, `adr`  |
-| **Story/task ref** | Traceability            | `issue-37`, `story-s003`, `prd-001`                    |
-| **Scope**          | How broad the impact    | `cross-repo`, `breaking-change`, `config-change`       |
-
-Every write SHOULD include tags from at least **2–3 layers**.
-
-### Before Inventing a Tag — Check What Exists
-
-```bash
-memo tags list --sort frequency --json
-```
-
-Re-use existing tags whenever possible. Consistent vocabulary is what allows `memo search` to surface related entries from weeks ago or from a different repository.
-
-### Tag Naming Rules
-
-- Kebab-case only: `rate-limiting`, not `rateLimiting` or `rate_limiting`.
-- Prefer specific over generic: `qdrant-collection` over `database`.
-- For story/task refs: `issue-37`, `story-s003` (numeric, no spaces).
-- Session markers: `intent` (beginning of task) and `outcome` (completion).
-- For cross-cutting concerns: `breaking-change`, `security`, `performance`, `config-change`.
-
-### Tag Examples by Scenario
-
-**Architectural decision on storage:**
+## Quick Command Card
 
 ```
-qdrant,collection-design,multi-tenancy,decision,adr
-```
-
-**Config change:**
-
-```
-config,env-vars,config-change,issue-42
-```
-
-**Integration contract between two services:**
-
-```
-api-contract,auth-service,cross-repo,integration-point,breaking-change
-```
-
-**Starting a new feature (intent):**
-
-```
-delete-command,safety,issue-37,intent
-```
-
-**Completing a feature (outcome):**
-
-```
-delete-command,safety,issue-37,outcome
-```
-
-**Performance trade-off:**
-
-```
-embeddings,openai,performance,trade-off,caching
-```
-
----
-
-## Multi-Developer & Cross-Session Context
-
-`memo-cli` is designed so that **every agent and every developer shares the same decision history**. This is what enables continuity across days, team rotations, and parallel workstreams.
-
-### Shared Knowledge Base
-
-All entries are stored in a shared Qdrant instance. When Developer A (or Agent A) records a decision, Developer B can immediately find it via `memo search`. There is no per-user silo.
-
-### Cross-Repository Visibility
-
-Use `--scope related` to query across connected repositories:
-
-```bash
-memo search "auth contract" --scope related --json
-```
-
-This is critical for:
-
-- Microservice architectures where contracts span repos.
-- Agent workflows that touch multiple repositories in sequence.
-- Detecting when a decision in one repo contradicts a constraint in another.
-
-Configure related repos in `memo.config.json`:
-
-```json
-{
-  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
-}
-```
-
-### Session Continuity for Agents
-
-Agents are stateless between sessions. To maintain continuity:
-
-1. **Start every session** with `memo list` and `memo search` — always.
-2. **Write an intent entry** before starting significant work.
-3. **Write as you decide**, not as a batch at the end.
-4. **Write an outcome entry** when completing a task, including any deviations from intent.
-5. **Tag consistently** — check `memo tags list` before picking tags.
-
-### Multi-Day Work Pattern
-
-For work that spans multiple days:
-
-- **Day 1 end**: Write an outcome entry with current state, what's done, what's next, any open questions.
-- **Day 2 start**: `memo search "<task name or issue number>" --json` to restore exact context.
-- The tags `intent` and `outcome` combined with a story tag (e.g., `issue-37`) make the full arc of a feature retrievable as a timeline.
-
-### What to Record vs. What to Skip
-
-| Record                                        | Skip                                                        |
-| --------------------------------------------- | ----------------------------------------------------------- |
-| Architectural choices and their rationale     | Trivial implementation details (variable names, formatting) |
-| Technology selections with trade-off analysis | Routine bug fixes with no design impact                     |
-| Configuration changes that affect behavior    | Code style choices (use linters)                            |
-| API contracts and integration boundaries      | Dependency version bumps (use lockfile)                     |
-| Security-sensitive design choices             | Temporary workarounds expected to be removed within hours   |
-| Performance trade-offs and their context      | Generated code                                              |
-| Rejected alternatives and why                 | CI/build configuration (use config files)                   |
-| Constraints discovered during implementation  | Debugging steps                                             |
-
----
-
-## Memory Scopes (IDE / Agent Memory vs. memo-cli)
-
-Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each prevents both redundancy and gaps.
-
-| Scope                 | Where                  | Persistence                                    | Use For                                                                                     |
-| --------------------- | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **User memory**       | `/memories/`           | All workspaces, all sessions                   | Personal preferences, debugging patterns, general agent insights                            |
-| **Session memory**    | `/memories/session/`   | Current conversation only                      | Scratch notes, in-progress state, temporary checklists                                      |
-| **Repository memory** | `/memories/repo/`      | Current workspace                              | Repo gotchas, build commands, local conventions — fast-access notes for this repo           |
-| **memo-cli**          | Qdrant (shared remote) | Permanent, shared across all people and agents | Architectural decisions, integration contracts, structural choices, configuration rationale |
-
-### Decision Tree: Where Does This Information Belong?
-
-```
-Is it a decision, rationale, constraint, contract, or config choice?
-  └─ YES → memo write  (it belongs to the shared knowledge base)
-
-Is it a repo-specific gotcha or quick operational fact?
-  └─ YES → /memories/repo/ (and also memo write if it reflects a real design choice)
-
-Is it a personal preference or general agent pattern?
-  └─ YES → /memories/ (user memory)
-
-Is it temporary context that only matters for the current session?
-  └─ YES → /memories/session/
-```
-
-**Key principle:** If the information would help a _different_ developer or agent working in the same codebase — even a year from now — it belongs in `memo-cli`.
-
----
-
-## Safe Operation Guardrails
-
-### Non-Destructive Defaults
-
-- `memo delete` requires confirmation by default. Use `--yes` to skip only when you are certain.
-- Bulk delete (`--all-by-repo`, `--all-by-org`) is **blocked in `--json` mode** as a safety guard against accidental mass deletion by agents.
-- `memo write` detects duplicates and prompts for resolution rather than silently overwriting.
-
-### Agent Mode (`--json`)
-
-Agents **SHOULD** always pass `--json` for predictable, parseable output. Key behaviors in JSON mode:
-
-- All output is structured JSON on stdout.
-- Errors produce JSON error objects to stderr.
-- Interactive prompts are suppressed — flags must supply all decisions.
-- `--on-duplicate` is required when a duplicate is detected.
-- Bulk delete is prohibited.
-
-### Validation Before Writing
-
-Before `memo write`, agents SHOULD:
-
-1. Verify `memo setup validate` passes.
-2. Confirm tags are kebab-case (lowercase, hyphens only).
-3. Ensure rationale is meaningful (not placeholder text).
-4. Check for duplicates with `memo search` first.
-
-### Error Handling
-
-All `memo` commands exit with:
-
-- **0** — Success
-- **1** — Validation or user error (bad flags, invalid config)
-- **2** — Unexpected/infrastructure error (Qdrant down, embedding API failure)
-
-When a command fails:
-
-1. Read the error code and message from stderr.
-2. For exit code 1: fix the input and retry.
-3. For exit code 2: check connectivity (`QDRANT_URL`) and API keys before retrying.
-
-### Environment Variable Safety
-
-- **Never** log or output `EMBEDDINGS_API_KEY` or `QDRANT_API_KEY`.
-- Store credentials in `.env` (which should be in `.gitignore`).
-- For CI/CD, use secrets management rather than plaintext config.
-
----
-
-## Quick Reference Card
-
-```
-memo setup init --repo <r> --org <o> --domain <d>   # Initialize config
 memo setup validate                                   # Verify config
-memo setup show [--json]                              # Display config
-
-memo write --rationale "..." --tags "a,b,c" [--json]  # Record decision
-memo search "query" [--scope related] [--json]         # Semantic search
-memo list [--from DATE] [--to DATE] [--json]           # Browse entries
-memo tags list [--sort frequency] [--json]             # Discover tags
-memo inspect [--json]                                  # Global facets
-memo delete --id <uuid> [--json]                       # Delete entry
+memo write --rationale "..." --tags "a,b,c" --json    # Record decision
+memo search "query" [--scope related] --json          # Semantic search
+memo list [--limit N] --json                          # Browse recent
+memo tags list [--sort frequency] --json              # Discover tags
+memo inspect --json                                   # Global facets
+memo delete --id <uuid> --json                        # Delete entry
 ```
 
----
-
-## Installation in Another Repository
-
-1. **Copy** the `memo-cli-usage/` folder into `<your-repo>/.github/skills/`.
-2. **Add** the skill to your agent/skill registry (e.g., `AGENTS.md`):
-   ```markdown
-   | memo-cli-usage | `.github/skills/memo-cli-usage/` | Agent guidance for memo-cli operations | Any agent |
-   ```
-3. **Install** `memo-cli` as a dev dependency:
-   ```bash
-   pnpm add -D memo-cli   # or npm install -D memo-cli
-   ```
-4. **Configure** the repository:
-   ```bash
-   npx memo setup init --repo <name> --org <org> --domain <domain>
-   ```
-5. **Set** environment variables (`.env` or CI secrets):
-   ```
-   QDRANT_URL=http://localhost:6333
-   QDRANT_API_KEY=
-   EMBEDDINGS_PROVIDER=openai
-   EMBEDDINGS_API_KEY=sk-...
-   ```
-6. The skill is now active — any agent that loads it will know how to use `memo-cli`.
+> For full flag documentation, admin operations, environment setup, and detailed examples, read [`REFERENCE.md`](./REFERENCE.md).

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ Thumbs.db
 /docs/*.md
 !/docs/product-context.md
 !/docs/technical-guidelines.md
+!/docs/workflow-chains.md
+!/docs/agents-md-guidelines.md
 !/docs/requirements/
 
 # Ignore log files

--- a/.kiro/agents/developer.md
+++ b/.kiro/agents/developer.md
@@ -62,6 +62,12 @@ If the user provides a feature description or asks to create a PRD/spec/stories 
 
 ---
 
+## Steering Context Check
+
+> If no `workstream/tasks-*.md` file is open or referenced, load the implement steering by opening the relevant task file first. The implement playbook only activates when a matching workstream file is in context.
+
+---
+
 ## Non-Negotiable Operating Rules
 
 1. **Execute only:** You **MUST** only implement from existing task lists. You **MUST NOT** create PRDs, specifications, user stories, or refine scope. Redirect preparation requests to `product-engineer`.

--- a/.kiro/agents/product-engineer.md
+++ b/.kiro/agents/product-engineer.md
@@ -85,6 +85,12 @@ If any required input is missing, you **MUST** ask concise clarifying questions.
 
 ---
 
+## Steering Context Check
+
+> If no workstream planning artifact is open or referenced, open the relevant workstream file to ensure plan guidance loads. The plan playbook only activates when a matching workstream file is in context.
+
+---
+
 ## memo-cli Integration (When Available)
 
 ### Availability Check

--- a/.kiro/skills/activity-init/SKILL.md
+++ b/.kiro/skills/activity-init/SKILL.md
@@ -144,6 +144,14 @@ When the project includes JavaScript/TypeScript:
 - **Location:** `/docs/`
 - **Filenames:** `product-context.md`, `technical-guidelines.md`
 
+## AGENTS.md Sizing
+
+When generating or updating `AGENTS.md` during project initialization, you **MUST** follow the sizing guidelines in `docs/agents-md-guidelines.md`:
+
+- Target ~1,000 words (~1,350 tokens)
+- Include only operational per-turn guidance (agent roster, skill roster, instructions table, general rules)
+- Move reference content (workflow chains, prompt tables, verbose explanations) to `docs/`
+
 ## Final Instructions
 
 1. You **MUST NOT** start implementing anything.

--- a/.kiro/skills/memo-cli-usage/REFERENCE.md
+++ b/.kiro/skills/memo-cli-usage/REFERENCE.md
@@ -1,0 +1,798 @@
+# memo-cli Full Reference
+
+> This is the complete CLI documentation for `memo-cli`. For everyday usage patterns, see `SKILL.md`.
+> Agents: read this file when performing setup, configuration, admin operations, or when you need detailed flag documentation.
+
+# memo-cli Usage Skill
+
+Teach AI agents (and human developers) how to operate **memo-cli** — the agent-first CLI for capturing and querying architectural decisions stored in a shared Qdrant vector database.
+
+Use this skill whenever an agent needs to **read**, **write**, **search**, or **manage** decision entries in a repository that has `memo-cli` installed.
+
+> **Portability:** This skill is self-contained. Copy the `memo-cli-usage/` folder into any repository's `.github/skills/` directory and reference it from that repo's `AGENTS.md` or skill registry.
+
+---
+
+## Purpose
+
+`memo-cli` is the **shared memory** that keeps agents coherent across time, sessions, and projects. It is not a log. It is not a changelog. It is a curated, searchable record of the decisions that shaped the codebase — written with enough precision that anyone (human or agent) arriving days, weeks, or months later can understand **what was decided, why, and what it affected**.
+
+An agent that uses `memo-cli` well:
+
+- Narrates its reasoning as it acts, not only at the end.
+- Records the files it modifies and why those files were the right place.
+- Explains configuration and architectural choices so future agents don't re-derive them.
+- Tags entries consistently so discovery remains reliable across projects.
+
+### Success Outcomes
+
+Using memo-cli correctly SHOULD produce these outcomes:
+
+- Faster planning and implementation by reusing prior constraints and decisions.
+- Consistent execution across agents and sessions.
+- Auditable traceability from decision to issue/story, files, and commit evidence.
+- Better cross-repo contract safety when `--scope related` is used intentionally.
+
+---
+
+## Entry Purposes and Scope
+
+Every write MUST have one clear purpose. Do not combine multiple purposes into one long entry.
+
+| Purpose                    | What it captures                                     | Entry Type          | Required lifecycle tag |
+| -------------------------- | ---------------------------------------------------- | ------------------- | ---------------------- |
+| Intent                     | Planned approach, constraints, expected impact       | `decision`          | `intent`               |
+| Outcome                    | Delivered behavior and validation evidence           | `decision`          | `outcome`              |
+| Durable architecture       | Long-lived technical decisions and trade-offs        | `decision`          | `decision`             |
+| Integration contract       | Cross-boundary assumptions and compatibility details | `integration_point` | `contract`             |
+| Structural convention      | Module boundaries and naming/layout rules            | `structure`         | `structure`            |
+
+Write only reusable knowledge. Do not write routine activity noise that is already obvious from a diff.
+
+---
+
+## When to Write to memo-cli
+
+Write a memo entry **during** or **immediately after** any of these moments:
+
+| Trigger                                                                    | Entry Type               |
+| -------------------------------------------------------------------------- | ------------------------ |
+| Choosing a library, framework, or service                                  | `decision`               |
+| Choosing how to structure a module or data model                           | `decision` / `structure` |
+| Changing a config file and explaining why                                  | `decision`               |
+| Identifying or formalizing a cross-service contract                        | `integration_point`      |
+| Modifying critical files (entry points, core abstractions, schema)         | `decision`               |
+| Discovering a constraint (API limit, platform quirk, security requirement) | `decision`               |
+| Resolving a conflict between two approaches                                | `decision`               |
+| Establishing a naming or layout convention                                 | `structure`              |
+| Starting work on a story or task (intent entry)                            | `decision`               |
+| Completing a story or task (outcome entry)                                 | `decision`               |
+
+---
+
+## When to Search memo-cli
+
+Search **before** taking action, not only when stuck:
+
+| Situation                                      | Command                                               |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| Starting a session — restore context           | `memo list --limit 20 --json`                         |
+| Normalize vocabulary before writing            | `memo tags list --sort frequency --json`              |
+| Before making a design choice                  | `memo search "<topic>" --json`                        |
+| Before touching a file you haven't seen before | `memo search "<filename or module name>" --json`      |
+| Evaluating whether to add a dependency         | `memo search "<library name>" --scope related --json` |
+| Onboarding to an unfamiliar repo               | `memo inspect --json` then `memo list --json`         |
+
+### Required Read Sequence
+
+At session start, run reads in this exact order:
+
+1. `memo setup validate`
+2. `memo list --limit 20 --json`
+3. `memo tags list --sort frequency --json`
+4. `memo search "<current issue/story/title>" --limit 10 --json`
+5. `memo search "<key contract or dependency>" --scope related --limit 5 --json` (when boundary impact is expected)
+
+Before coding or planning, synthesize findings in 4 bullets:
+
+- Constraints to preserve
+- Rejected alternatives to avoid
+- Contracts/boundaries that must remain stable
+- Sensitive files/modules to treat carefully
+
+---
+
+## Minimum Entry Schema
+
+All entries SHOULD include these fields when applicable:
+
+- Scope: issue/story identifier (`issue-<n>` or `story-<id>`)
+- Context: what changed and why now
+- Decision/Delivery: what was chosen or implemented
+- Impact: downstream behavior or contracts affected
+- Evidence: commit SHA and key files (`outcome` required)
+
+Additional requirements by purpose:
+
+- Intent entries MUST include constraints/non-goals and expected files.
+- Outcome entries MUST include AC coverage and quality gate status (`test`, `lint`, `format:check`, `typecheck`, `audit`).
+- Contract entries MUST include producer, consumer, validation rules, and failure behavior.
+
+---
+
+## Tag Taxonomy Standard
+
+Tags MUST be kebab-case and ordered in these layers:
+
+1. Domain tag (for example: `auth`, `tenant`, `ingestion`, `docs`)
+2. Work-item tag (`issue-113`, `story-s003`)
+3. Lifecycle tag (`intent`, `outcome`, `decision`, `contract`, `structure`)
+4. Impact/quality tag (`security`, `migration`, `gates-pass`, `docs-drift-fixed`)
+5. Optional boundary tag (`api`, `middleware`, `cross-repo`)
+
+Use 4-5 tags whenever possible. Reuse existing tags from `memo tags list`.
+
+---
+
+## Prerequisites
+
+### Environment Variables
+
+The following variables **MUST** be set before any `memo` command will work:
+
+| Variable              | Purpose                   | Example                 |
+| --------------------- | ------------------------- | ----------------------- |
+| `QDRANT_URL`          | Qdrant instance endpoint  | `http://localhost:6333` |
+| `QDRANT_API_KEY`      | API key (empty for local) | `""` or a cloud key     |
+| `EMBEDDINGS_PROVIDER` | Embedding backend         | `openai`                |
+| `EMBEDDINGS_API_KEY`  | Provider secret key       | `sk-...`                |
+
+> **Tip:** Store these in a `.env` file at the repository root. `memo-cli` loads it automatically via `dotenv`.
+
+### Repository Configuration
+
+A `memo.config.json` **MUST** exist at the repository root. Create one with:
+
+```bash
+memo setup init --repo <repo-name> --org <org-name> --domain <domain> [--relates-to repo1,repo2]
+```
+
+Verify it at any time:
+
+```bash
+memo setup validate   # exit 0 = valid
+memo setup show       # print effective config
+```
+
+---
+
+## Core Concepts
+
+### `repo` — Repository Identity
+
+`repo` is the **name of the codebase** this entry belongs to. It is set in `memo.config.json` and defaults into every `memo write` call automatically. Use the kebab-case name of the Git repository (e.g., `memo-cli`, `auth-service`, `api-gateway`).
+
+**Why it matters:** Every entry is scoped to a repo. `memo search` and `memo list` filter by your current repo by default, so entries from other repos don't pollute your results unless you explicitly request them with `--scope related`.
+
+**Rule:** Use the repo's canonical name — the one that appears in the GitHub URL. Don't abbreviate or alias it.
+
+---
+
+### `org` — Organization
+
+`org` is the **owner or organization** that the repository belongs to. In GitHub terms, this is the account or org username (e.g., `llipe`, `acme-corp`, `my-team`).
+
+**Why it matters:** `org` groups related repositories under a common owner. It enables cross-repo queries scoped to a single organization — e.g., finding all decisions made under `acme-corp` across all its services.
+
+**Rule:** Use the GitHub organization or user handle, kebab-case. All repos under the same team should share the same `org` value.
+
+---
+
+### `domain` — Product or Functional Area
+
+`domain` describes the **product area or functional concern** that this repository serves (e.g., `auth`, `payments`, `infra`, `ai`, `search`, `notifications`). It is broader than a repository — multiple repos can share the same domain.
+
+**Why it matters:** Domain is a cross-cutting label that lets you query decisions across all repos in a functional area. For example, all `auth`-domain decisions across `auth-service`, `api-gateway`, and `user-service` can be retrieved together.
+
+**How to choose:**
+
+- Use the business or technical capability, not the team name.
+- Keep it stable — domains change less often than repos.
+- Examples: `auth`, `billing`, `data-pipeline`, `mobile`, `platform`, `ai`, `infra`, `developer-tools`.
+
+---
+
+### `relates_to` — Connected Repositories
+
+`relates_to` is an **explicit list of other repository names** that this repo has a meaningful relationship with — shared contracts, shared schemas, upstream/downstream dependencies, or simply repos that an agent often works across together.
+
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
+
+**Why it matters:** Setting `relates_to` enables `--scope related` queries, which search entries across this repo **and** all listed repos simultaneously. This is how agents and developers get cross-service context without switching repositories.
+
+**When to add a repo to `relates_to`:**
+
+- This repo consumes an API or event contract that the other repo owns.
+- Decisions in the other repo often directly constrain decisions in this one.
+- You regularly need to cross-reference both repos during feature work.
+- They share a data model or schema.
+
+**Rule:** Keep `relates_to` intentional — list real dependencies, not every repo in the org. A bloated list degrades search signal.
+
+---
+
+### Entry Types
+
+| Type                | When to use                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `decision`          | Architectural or design choices ("We chose Postgres over Mongo because…") |
+| `integration_point` | Cross-service contracts, API boundaries, shared schemas                   |
+| `structure`         | Folder layout, module boundaries, naming conventions                      |
+
+### Source
+
+| Value    | Meaning                                                        |
+| -------- | -------------------------------------------------------------- |
+| `agent`  | Written by an AI agent (default when `defaults.source` is set) |
+| `manual` | Written by a human developer                                   |
+
+### Scoping
+
+Every entry belongs to a **repo**, **org**, and **domain** (all kebab-case). Queries default to the current repo context from `memo.config.json`.
+
+- `--scope repo` — Only entries for the current repository.
+- `--scope related` — Current repository + all repos listed in `relates_to`.
+
+---
+
+## Command Reference
+
+### `memo write` — Record a Decision
+
+```bash
+memo write \
+  --rationale "Chose JWT over session cookies for stateless auth across services" \
+  --tags "auth,jwt,stateless" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+**Required flags:**
+
+- `--rationale` — The decision text (1–5 000 chars).
+- `--tags` — 2–5 comma-separated kebab-case tags.
+
+**Optional flags:**
+
+- `--entry-type` — `decision` (default) | `integration_point` | `structure`
+- `--source` — `agent` | `manual` (falls back to config default)
+- `--commit` — Git commit SHA for traceability
+- `--story` — Story or task ID
+- `--files` — Comma-separated file paths touched by the decision
+- `--relates-to` — Related repo names
+- `--on-duplicate` — `consolidate` | `update` | `replace` | `create-new`
+- `--json` — Machine-readable output (**always use in agent mode**)
+
+**Duplicate handling:**
+When memo detects a duplicate (same `repo + commit + story + entry_type + source`), interactive mode prompts for resolution. In `--json` mode you **MUST** supply `--on-duplicate` or the command will fail.
+
+---
+
+### `memo search` — Semantic Search
+
+```bash
+memo search "rate limiting strategy" --limit 5 --json
+```
+
+Natural-language vector search over decision entries.
+
+**Optional flags:**
+
+- `--scope` — `repo` (default) | `related`
+- `--tags` — Comma-separated filter (AND logic)
+- `--entry-type` — Filter by type
+- `--source` — Filter by source
+- `--limit` — Max results (default 10)
+- `--json` — Machine-readable output
+
+---
+
+### `memo list` — Chronological Browse
+
+```bash
+memo list --limit 20 --json
+```
+
+Most-recent-first listing with optional date range.
+
+**Optional flags:**
+
+- `--scope`, `--tags`, `--entry-type`, `--source` — Same as search
+- `--from` / `--to` — ISO 8601 date boundaries
+- `--limit` — Max results (default 20)
+- `--json` — Machine-readable output
+
+---
+
+### `memo tags list` — Discover Tags
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Shows all unique tags with entry counts.
+
+**Optional flags:**
+
+- `--scope` — `repo` | `related`
+- `--sort` — `alpha` (default) | `frequency`
+- `--json` — Machine-readable output
+
+---
+
+### `memo inspect` — Global Facet Discovery
+
+```bash
+memo inspect --json
+```
+
+Lists all organizations, repositories, and domains across the entire knowledge base (ignores repo scope). Useful for onboarding and cross-team exploration.
+
+**Optional flags:**
+
+- `--orgs` / `--repos` / `--domains` — Show only one facet
+- `--json` — Machine-readable output
+
+---
+
+### `memo delete` — Remove Entries
+
+**Single entry:**
+
+```bash
+memo delete --id <uuid> --json
+```
+
+**Bulk (interactive only — blocked in `--json` mode for safety):**
+
+```bash
+memo delete --all-by-repo <repo-name> --yes
+memo delete --all-by-org <org-name> --yes
+```
+
+Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
+
+---
+
+## Agent Workflows
+
+### Starting a Session — Restore Context
+
+At the **beginning of every session**, run this sequence before writing a single line of code:
+
+```bash
+# 1. Confirm config is valid
+memo setup validate
+
+# 2. Discover what repos/orgs/domains exist
+memo inspect --json
+
+# 3. Review recent decisions for this repo
+memo list --limit 20 --json
+
+# 4. Check the established tag vocabulary
+memo tags list --sort frequency --json
+
+# 5. Search for context relevant to the current task
+memo search "<current task or feature description>" --limit 10 --json
+```
+
+Read the results before proceeding. Prior entries may contain constraints, preferred patterns, or rejected alternatives that directly affect how you should approach the current task.
+
+---
+
+### Recording Decisions — As You Work, Not Only at the End
+
+Write a memo entry **at the moment you make a decision**, not as a post-hoc summary. This preserves the full reasoning before context is lost.
+
+**Template:**
+
+```bash
+memo write \
+  --rationale "CONTEXT. DECISION. RATIONALE." \
+  --tags "tag1,tag2,tag3" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --story "ISSUE-42" \
+  --files "path/to/file1.ts,path/to/file2.ts" \
+  --json
+```
+
+The `--rationale` field is the most important field. See **Writing Quality** below.
+
+---
+
+### Recording File Changes — Explain the Why
+
+When modifying a significant file (entry point, core abstraction, schema, config), record what changed and why:
+
+```bash
+memo write \
+  --rationale "Modified src/lib/config.ts to add schema_version validation. The config loader previously accepted any object; adding Zod validation ensures CLI commands fail fast on malformed configs rather than producing silent errors downstream." \
+  --tags "config,validation,config-ts,error-handling" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --files "src/lib/config.ts,src/types/config.ts" \
+  --json
+```
+
+---
+
+### Recording Configuration Decisions
+
+Configuration decisions are especially important to preserve — they often appear opaque later with no obvious rationale in the code.
+
+```bash
+memo write \
+  --rationale "Set QDRANT_COLLECTION_NAME to 'decisions' permanently rather than making it configurable. A single collection per deployment simplifies queries and access control. Multi-tenancy is achieved via repo/org payload fields, not separate collections. Reconsidering this would require a data migration." \
+  --tags "qdrant,config,multi-tenancy,collection-design" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+Configuration decisions to always record:
+
+- Environment variable semantics (what the value controls, valid ranges, defaults)
+- Feature flags and their trigger conditions
+- Schema versions and migration policies
+- Storage layout choices (collection names, index strategies, partitioning)
+- Security-related configuration (TLS, auth, CORS, rate limits)
+
+---
+
+### Intent Entry — Narrate Before Acting
+
+For significant tasks, write an **intent entry** before starting implementation. This creates a checkpoint that future sessions can find, and anchors the rationale for every decision that follows.
+
+```bash
+memo write \
+  --rationale "Starting implementation of story ISSUE-37: safe delete command. Approach: add a --yes flag for non-interactive confirmation, block --json with bulk delete flags (safety guard for agents), preview affected entries before deletion. No soft-delete; permanent removal via Qdrant point deletion. This matches the existing write/search command pattern." \
+  --tags "delete,safety,issue-37,intent" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --json
+```
+
+---
+
+### Outcome Entry — Summarize After Completing
+
+When finishing a task, write an **outcome entry** that captures what actually happened vs. what was intended:
+
+```bash
+memo write \
+  --rationale "Completed ISSUE-37 safe delete command. Shipped: --id single delete, --all-by-repo and --all-by-org bulk delete (interactive only), --yes to skip confirm, preview before deletion. Deviation from intent: bulk delete also disallowed with --json (not just flagged) after discovering Qdrant batch delete has no confirmation step. Modified: src/commands/delete.ts (new), tests/unit/commands/delete.test.ts (new)." \
+  --tags "delete,safety,issue-37,outcome" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --files "src/commands/delete.ts,tests/unit/commands/delete.test.ts" \
+  --json
+```
+
+---
+
+## Writing Quality
+
+The `--rationale` field must be **precise enough that a different developer or agent — with no prior context — can understand what was decided, why, and what it affects.** A good entry answers three questions:
+
+1. **Context** — What is the situation, constraint, or problem?
+2. **Decision** — What was chosen or done?
+3. **Rationale** — Why this choice over the alternatives?
+
+### Good vs. Bad Examples
+
+**Too vague — useless to a future reader:**
+
+> "Updated auth to use JWT."
+
+**Precise — useful across sessions and developers:**
+
+> "Switched authentication from server-side sessions to JWT (HS256, 15-min access + 7-day refresh). Sessions required sticky routing which is incompatible with the planned horizontal scaling. JWTs are stateless — any instance can validate without a shared session store. Trade-off: revocation requires a Redis blacklist (added to ISSUE-51 backlog). Files: src/auth/jwt.ts, src/middleware/auth.ts."
+
+---
+
+**Too vague:**
+
+> "Changed config validation."
+
+**Precise:**
+
+> "Added Zod validation to memo.config.json loader (src/lib/config.ts). Previously the code trusted the file's shape; malformed configs caused cryptic runtime errors deep in Qdrant queries. Now the CLI fails immediately at startup with a structured error message. This is the single place config is read — no other validation needed."
+
+---
+
+**Too vague:**
+
+> "Used Redis for caching."
+
+**Precise:**
+
+> "Chose Redis (via ioredis) over in-process LRU cache for rate-limit counters. In-process cache doesn't survive pod restarts and is not shared across replicas. Redis TTL natively aligns with the sliding window algorithm. Accepted dependency: Redis must be available in all environments. Config: REDIS_URL env var, no auth in dev, TLS required in prod."
+
+---
+
+### Structural Rule
+
+Write `--rationale` as a single coherent paragraph (or 2-3 short sentences). **Avoid bullet points** in the rationale field — they fragment reasoning and lose connective logic. Save structure for tags.
+
+Minimum viable rationale: **context sentence + decision sentence + why sentence**.
+
+---
+
+## Tag Strategy
+
+Tags are the primary way to discover entries. Good tagging makes the difference between a searchable knowledge base and an unsearchable archive.
+
+### Tag Layers
+
+Apply tags across **multiple layers** simultaneously:
+
+| Layer              | Purpose                 | Examples                                               |
+| ------------------ | ----------------------- | ------------------------------------------------------ |
+| **Domain/feature** | What area of the system | `auth`, `rate-limiting`, `config`, `delete`, `storage` |
+| **Technology**     | What tech is involved   | `qdrant`, `redis`, `openai`, `zod`, `jwt`              |
+| **Entry nature**   | What kind of change     | `intent`, `outcome`, `constraint`, `trade-off`, `adr`  |
+| **Story/task ref** | Traceability            | `issue-37`, `story-s003`, `prd-001`                    |
+| **Scope**          | How broad the impact    | `cross-repo`, `breaking-change`, `config-change`       |
+
+Every write SHOULD include tags from at least **2–3 layers**.
+
+### Before Inventing a Tag — Check What Exists
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Re-use existing tags whenever possible. Consistent vocabulary is what allows `memo search` to surface related entries from weeks ago or from a different repository.
+
+### Tag Naming Rules
+
+- Kebab-case only: `rate-limiting`, not `rateLimiting` or `rate_limiting`.
+- Prefer specific over generic: `qdrant-collection` over `database`.
+- For story/task refs: `issue-37`, `story-s003` (numeric, no spaces).
+- Session markers: `intent` (beginning of task) and `outcome` (completion).
+- For cross-cutting concerns: `breaking-change`, `security`, `performance`, `config-change`.
+
+### Tag Examples by Scenario
+
+**Architectural decision on storage:**
+
+```
+qdrant,collection-design,multi-tenancy,decision,adr
+```
+
+**Config change:**
+
+```
+config,env-vars,config-change,issue-42
+```
+
+**Integration contract between two services:**
+
+```
+api-contract,auth-service,cross-repo,integration-point,breaking-change
+```
+
+**Starting a new feature (intent):**
+
+```
+delete-command,safety,issue-37,intent
+```
+
+**Completing a feature (outcome):**
+
+```
+delete-command,safety,issue-37,outcome
+```
+
+**Performance trade-off:**
+
+```
+embeddings,openai,performance,trade-off,caching
+```
+
+---
+
+## Multi-Developer & Cross-Session Context
+
+`memo-cli` is designed so that **every agent and every developer shares the same decision history**. This is what enables continuity across days, team rotations, and parallel workstreams.
+
+### Shared Knowledge Base
+
+All entries are stored in a shared Qdrant instance. When Developer A (or Agent A) records a decision, Developer B can immediately find it via `memo search`. There is no per-user silo.
+
+### Cross-Repository Visibility
+
+Use `--scope related` to query across connected repositories:
+
+```bash
+memo search "auth contract" --scope related --json
+```
+
+This is critical for:
+
+- Microservice architectures where contracts span repos.
+- Agent workflows that touch multiple repositories in sequence.
+- Detecting when a decision in one repo contradicts a constraint in another.
+
+Configure related repos in `memo.config.json`:
+
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
+
+### Session Continuity for Agents
+
+Agents are stateless between sessions. To maintain continuity:
+
+1. **Start every session** with `memo list` and `memo search` — always.
+2. **Write an intent entry** before starting significant work.
+3. **Write as you decide**, not as a batch at the end.
+4. **Write an outcome entry** when completing a task, including any deviations from intent.
+5. **Tag consistently** — check `memo tags list` before picking tags.
+
+### Multi-Day Work Pattern
+
+For work that spans multiple days:
+
+- **Day 1 end**: Write an outcome entry with current state, what's done, what's next, any open questions.
+- **Day 2 start**: `memo search "<task name or issue number>" --json` to restore exact context.
+- The tags `intent` and `outcome` combined with a story tag (e.g., `issue-37`) make the full arc of a feature retrievable as a timeline.
+
+### What to Record vs. What to Skip
+
+| Record                                        | Skip                                                        |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| Architectural choices and their rationale     | Trivial implementation details (variable names, formatting) |
+| Technology selections with trade-off analysis | Routine bug fixes with no design impact                     |
+| Configuration changes that affect behavior    | Code style choices (use linters)                            |
+| API contracts and integration boundaries      | Dependency version bumps (use lockfile)                     |
+| Security-sensitive design choices             | Temporary workarounds expected to be removed within hours   |
+| Performance trade-offs and their context      | Generated code                                              |
+| Rejected alternatives and why                 | CI/build configuration (use config files)                   |
+| Constraints discovered during implementation  | Debugging steps                                             |
+
+---
+
+## Memory Scopes (IDE / Agent Memory vs. memo-cli)
+
+Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each prevents both redundancy and gaps.
+
+| Scope                 | Where                  | Persistence                                    | Use For                                                                                     |
+| --------------------- | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **User memory**       | `/memories/`           | All workspaces, all sessions                   | Personal preferences, debugging patterns, general agent insights                            |
+| **Session memory**    | `/memories/session/`   | Current conversation only                      | Scratch notes, in-progress state, temporary checklists                                      |
+| **Repository memory** | `/memories/repo/`      | Current workspace                              | Repo gotchas, build commands, local conventions — fast-access notes for this repo           |
+| **memo-cli**          | Qdrant (shared remote) | Permanent, shared across all people and agents | Architectural decisions, integration contracts, structural choices, configuration rationale |
+
+### Decision Tree: Where Does This Information Belong?
+
+```
+Is it a decision, rationale, constraint, contract, or config choice?
+  └─ YES → memo write  (it belongs to the shared knowledge base)
+
+Is it a repo-specific gotcha or quick operational fact?
+  └─ YES → /memories/repo/ (and also memo write if it reflects a real design choice)
+
+Is it a personal preference or general agent pattern?
+  └─ YES → /memories/ (user memory)
+
+Is it temporary context that only matters for the current session?
+  └─ YES → /memories/session/
+```
+
+**Key principle:** If the information would help a _different_ developer or agent working in the same codebase — even a year from now — it belongs in `memo-cli`.
+
+---
+
+## Safe Operation Guardrails
+
+### Non-Destructive Defaults
+
+- `memo delete` requires confirmation by default. Use `--yes` to skip only when you are certain.
+- Bulk delete (`--all-by-repo`, `--all-by-org`) is **blocked in `--json` mode** as a safety guard against accidental mass deletion by agents.
+- `memo write` detects duplicates and prompts for resolution rather than silently overwriting.
+
+### Agent Mode (`--json`)
+
+Agents **SHOULD** always pass `--json` for predictable, parseable output. Key behaviors in JSON mode:
+
+- All output is structured JSON on stdout.
+- Errors produce JSON error objects to stderr.
+- Interactive prompts are suppressed — flags must supply all decisions.
+- `--on-duplicate` is required when a duplicate is detected.
+- Bulk delete is prohibited.
+
+### Validation Before Writing
+
+Before `memo write`, agents SHOULD:
+
+1. Verify `memo setup validate` passes.
+2. Confirm tags are kebab-case (lowercase, hyphens only).
+3. Ensure rationale is meaningful (not placeholder text).
+4. Check for duplicates with `memo search` first.
+
+### Error Handling
+
+All `memo` commands exit with:
+
+- **0** — Success
+- **1** — Validation or user error (bad flags, invalid config)
+- **2** — Unexpected/infrastructure error (Qdrant down, embedding API failure)
+
+When a command fails:
+
+1. Read the error code and message from stderr.
+2. For exit code 1: fix the input and retry.
+3. For exit code 2: check connectivity (`QDRANT_URL`) and API keys before retrying.
+
+### Environment Variable Safety
+
+- **Never** log or output `EMBEDDINGS_API_KEY` or `QDRANT_API_KEY`.
+- Store credentials in `.env` (which should be in `.gitignore`).
+- For CI/CD, use secrets management rather than plaintext config.
+
+---
+
+## Quick Reference Card
+
+```
+memo setup init --repo <r> --org <o> --domain <d>   # Initialize config
+memo setup validate                                   # Verify config
+memo setup show [--json]                              # Display config
+
+memo write --rationale "..." --tags "a,b,c" [--json]  # Record decision
+memo search "query" [--scope related] [--json]         # Semantic search
+memo list [--from DATE] [--to DATE] [--json]           # Browse entries
+memo tags list [--sort frequency] [--json]             # Discover tags
+memo inspect [--json]                                  # Global facets
+memo delete --id <uuid> [--json]                       # Delete entry
+```
+
+---
+
+## Installation in Another Repository
+
+1. **Copy** the `memo-cli-usage/` folder into `<your-repo>/.github/skills/`.
+2. **Add** the skill to your agent/skill registry (e.g., `AGENTS.md`):
+   ```markdown
+   | memo-cli-usage | `.github/skills/memo-cli-usage/` | Agent guidance for memo-cli operations | Any agent |
+   ```
+3. **Install** `memo-cli` as a dev dependency:
+   ```bash
+   pnpm add -D memo-cli   # or npm install -D memo-cli
+   ```
+4. **Configure** the repository:
+   ```bash
+   npx memo setup init --repo <name> --org <org> --domain <domain>
+   ```
+5. **Set** environment variables (`.env` or CI secrets):
+   ```
+   QDRANT_URL=http://localhost:6333
+   QDRANT_API_KEY=
+   EMBEDDINGS_PROVIDER=openai
+   EMBEDDINGS_API_KEY=sk-...
+   ```
+6. The skill is now active — any agent that loads it will know how to use `memo-cli`.

--- a/.kiro/skills/memo-cli-usage/SKILL.md
+++ b/.kiro/skills/memo-cli-usage/SKILL.md
@@ -3,98 +3,34 @@ name: memo-cli-usage
 description: "Read and write architectural decisions to the shared memo-cli knowledge base. Use when recording or restoring cross-session context."
 ---
 
-# memo-cli Usage Skill
+# memo-cli Usage — Quick Reference
 
-Teach AI agents (and human developers) how to operate **memo-cli** — the agent-first CLI for capturing and querying architectural decisions stored in a shared Qdrant vector database.
-
-Use this skill whenever an agent needs to **read**, **write**, **search**, or **manage** decision entries in a repository that has `memo-cli` installed.
-
-> **Portability:** This skill is self-contained. Copy the `memo-cli-usage/` folder into any repository's `.github/skills/` directory and reference it from that repo's `AGENTS.md` or skill registry.
+Operate `memo-cli` for reading and writing architectural decisions in a shared Qdrant vector database. For full CLI documentation (all flags, configuration, admin operations, schema details), see [`REFERENCE.md`](./REFERENCE.md).
 
 ---
 
-## Purpose
+## Setup Validation
 
-`memo-cli` is the **shared memory** that keeps agents coherent across time, sessions, and projects. It is not a log. It is not a changelog. It is a curated, searchable record of the decisions that shaped the codebase — written with enough precision that anyone (human or agent) arriving days, weeks, or months later can understand **what was decided, why, and what it affected**.
+```bash
+memo setup validate   # exit 0 = configured correctly
+```
 
-An agent that uses `memo-cli` well:
-
-- Narrates its reasoning as it acts, not only at the end.
-- Records the files it modifies and why those files were the right place.
-- Explains configuration and architectural choices so future agents don't re-derive them.
-- Tags entries consistently so discovery remains reliable across projects.
-
-### Success Outcomes
-
-Using memo-cli correctly SHOULD produce these outcomes:
-
-- Faster planning and implementation by reusing prior constraints and decisions.
-- Consistent execution across agents and sessions.
-- Auditable traceability from decision to issue/story, files, and commit evidence.
-- Better cross-repo contract safety when `--scope related` is used intentionally.
+If validation fails, run: `memo setup init --repo <repo> --org <org> --domain <domain>`
 
 ---
 
-## Entry Purposes and Scope
+## Session Start — Restore Context
 
-Every write MUST have one clear purpose. Do not combine multiple purposes into one long entry.
+Run before writing any code:
 
-| Purpose                    | What it captures                                     | Entry Type          | Required lifecycle tag |
-| -------------------------- | ---------------------------------------------------- | ------------------- | ---------------------- |
-| Intent                     | Planned approach, constraints, expected impact       | `decision`          | `intent`               |
-| Outcome                    | Delivered behavior and validation evidence           | `decision`          | `outcome`              |
-| Durable architecture       | Long-lived technical decisions and trade-offs        | `decision`          | `decision`             |
-| Integration contract       | Cross-boundary assumptions and compatibility details | `integration_point` | `contract`             |
-| Structural convention      | Module boundaries and naming/layout rules            | `structure`         | `structure`            |
+```bash
+memo list --limit 20 --json
+memo tags list --sort frequency --json
+memo search "<current task description>" --limit 10 --json
+memo search "<key contract or dependency>" --scope related --limit 5 --json
+```
 
-Write only reusable knowledge. Do not write routine activity noise that is already obvious from a diff.
-
----
-
-## When to Write to memo-cli
-
-Write a memo entry **during** or **immediately after** any of these moments:
-
-| Trigger                                                                    | Entry Type               |
-| -------------------------------------------------------------------------- | ------------------------ |
-| Choosing a library, framework, or service                                  | `decision`               |
-| Choosing how to structure a module or data model                           | `decision` / `structure` |
-| Changing a config file and explaining why                                  | `decision`               |
-| Identifying or formalizing a cross-service contract                        | `integration_point`      |
-| Modifying critical files (entry points, core abstractions, schema)         | `decision`               |
-| Discovering a constraint (API limit, platform quirk, security requirement) | `decision`               |
-| Resolving a conflict between two approaches                                | `decision`               |
-| Establishing a naming or layout convention                                 | `structure`              |
-| Starting work on a story or task (intent entry)                            | `decision`               |
-| Completing a story or task (outcome entry)                                 | `decision`               |
-
----
-
-## When to Search memo-cli
-
-Search **before** taking action, not only when stuck:
-
-| Situation                                      | Command                                               |
-| ---------------------------------------------- | ----------------------------------------------------- |
-| Starting a session — restore context           | `memo list --limit 20 --json`                         |
-| Normalize vocabulary before writing            | `memo tags list --sort frequency --json`              |
-| Before making a design choice                  | `memo search "<topic>" --json`                        |
-| Before touching a file you haven't seen before | `memo search "<filename or module name>" --json`      |
-| Evaluating whether to add a dependency         | `memo search "<library name>" --scope related --json` |
-| Onboarding to an unfamiliar repo               | `memo inspect --json` then `memo list --json`         |
-
-### Required Read Sequence
-
-At session start, run reads in this exact order:
-
-1. `memo setup validate`
-2. `memo list --limit 20 --json`
-3. `memo tags list --sort frequency --json`
-4. `memo search "<current issue/story/title>" --limit 10 --json`
-5. `memo search "<key contract or dependency>" --scope related --limit 5 --json` (when boundary impact is expected)
-
-Before coding or planning, synthesize findings in 4 bullets:
-
+Synthesize findings into:
 - Constraints to preserve
 - Rejected alternatives to avoid
 - Contracts/boundaries that must remain stable
@@ -102,697 +38,106 @@ Before coding or planning, synthesize findings in 4 bullets:
 
 ---
 
-## Minimum Entry Schema
+## Writing Entries
 
-All entries SHOULD include these fields when applicable:
-
-- Scope: issue/story identifier (`issue-<n>` or `story-<id>`)
-- Context: what changed and why now
-- Decision/Delivery: what was chosen or implemented
-- Impact: downstream behavior or contracts affected
-- Evidence: commit SHA and key files (`outcome` required)
-
-Additional requirements by purpose:
-
-- Intent entries MUST include constraints/non-goals and expected files.
-- Outcome entries MUST include AC coverage and quality gate status (`test`, `lint`, `format:check`, `typecheck`, `audit`).
-- Contract entries MUST include producer, consumer, validation rules, and failure behavior.
-
----
-
-## Tag Taxonomy Standard
-
-Tags MUST be kebab-case and ordered in these layers:
-
-1. Domain tag (for example: `auth`, `tenant`, `ingestion`, `docs`)
-2. Work-item tag (`issue-113`, `story-s003`)
-3. Lifecycle tag (`intent`, `outcome`, `decision`, `contract`, `structure`)
-4. Impact/quality tag (`security`, `migration`, `gates-pass`, `docs-drift-fixed`)
-5. Optional boundary tag (`api`, `middleware`, `cross-repo`)
-
-Use 4-5 tags whenever possible. Reuse existing tags from `memo tags list`.
-
----
-
-## Prerequisites
-
-### Environment Variables
-
-The following variables **MUST** be set before any `memo` command will work:
-
-| Variable              | Purpose                   | Example                 |
-| --------------------- | ------------------------- | ----------------------- |
-| `QDRANT_URL`          | Qdrant instance endpoint  | `http://localhost:6333` |
-| `QDRANT_API_KEY`      | API key (empty for local) | `""` or a cloud key     |
-| `EMBEDDINGS_PROVIDER` | Embedding backend         | `openai`                |
-| `EMBEDDINGS_API_KEY`  | Provider secret key       | `sk-...`                |
-
-> **Tip:** Store these in a `.env` file at the repository root. `memo-cli` loads it automatically via `dotenv`.
-
-### Repository Configuration
-
-A `memo.config.json` **MUST** exist at the repository root. Create one with:
-
-```bash
-memo setup init --repo <repo-name> --org <org-name> --domain <domain> [--relates-to repo1,repo2]
-```
-
-Verify it at any time:
-
-```bash
-memo setup validate   # exit 0 = valid
-memo setup show       # print effective config
-```
-
----
-
-## Core Concepts
-
-### `repo` — Repository Identity
-
-`repo` is the **name of the codebase** this entry belongs to. It is set in `memo.config.json` and defaults into every `memo write` call automatically. Use the kebab-case name of the Git repository (e.g., `memo-cli`, `auth-service`, `api-gateway`).
-
-**Why it matters:** Every entry is scoped to a repo. `memo search` and `memo list` filter by your current repo by default, so entries from other repos don't pollute your results unless you explicitly request them with `--scope related`.
-
-**Rule:** Use the repo's canonical name — the one that appears in the GitHub URL. Don't abbreviate or alias it.
-
----
-
-### `org` — Organization
-
-`org` is the **owner or organization** that the repository belongs to. In GitHub terms, this is the account or org username (e.g., `llipe`, `acme-corp`, `my-team`).
-
-**Why it matters:** `org` groups related repositories under a common owner. It enables cross-repo queries scoped to a single organization — e.g., finding all decisions made under `acme-corp` across all its services.
-
-**Rule:** Use the GitHub organization or user handle, kebab-case. All repos under the same team should share the same `org` value.
-
----
-
-### `domain` — Product or Functional Area
-
-`domain` describes the **product area or functional concern** that this repository serves (e.g., `auth`, `payments`, `infra`, `ai`, `search`, `notifications`). It is broader than a repository — multiple repos can share the same domain.
-
-**Why it matters:** Domain is a cross-cutting label that lets you query decisions across all repos in a functional area. For example, all `auth`-domain decisions across `auth-service`, `api-gateway`, and `user-service` can be retrieved together.
-
-**How to choose:**
-
-- Use the business or technical capability, not the team name.
-- Keep it stable — domains change less often than repos.
-- Examples: `auth`, `billing`, `data-pipeline`, `mobile`, `platform`, `ai`, `infra`, `developer-tools`.
-
----
-
-### `relates_to` — Connected Repositories
-
-`relates_to` is an **explicit list of other repository names** that this repo has a meaningful relationship with — shared contracts, shared schemas, upstream/downstream dependencies, or simply repos that an agent often works across together.
-
-```json
-{
-  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
-}
-```
-
-**Why it matters:** Setting `relates_to` enables `--scope related` queries, which search entries across this repo **and** all listed repos simultaneously. This is how agents and developers get cross-service context without switching repositories.
-
-**When to add a repo to `relates_to`:**
-
-- This repo consumes an API or event contract that the other repo owns.
-- Decisions in the other repo often directly constrain decisions in this one.
-- You regularly need to cross-reference both repos during feature work.
-- They share a data model or schema.
-
-**Rule:** Keep `relates_to` intentional — list real dependencies, not every repo in the org. A bloated list degrades search signal.
-
----
-
-### Entry Types
-
-| Type                | When to use                                                               |
-| ------------------- | ------------------------------------------------------------------------- |
-| `decision`          | Architectural or design choices ("We chose Postgres over Mongo because…") |
-| `integration_point` | Cross-service contracts, API boundaries, shared schemas                   |
-| `structure`         | Folder layout, module boundaries, naming conventions                      |
-
-### Source
-
-| Value    | Meaning                                                        |
-| -------- | -------------------------------------------------------------- |
-| `agent`  | Written by an AI agent (default when `defaults.source` is set) |
-| `manual` | Written by a human developer                                   |
-
-### Scoping
-
-Every entry belongs to a **repo**, **org**, and **domain** (all kebab-case). Queries default to the current repo context from `memo.config.json`.
-
-- `--scope repo` — Only entries for the current repository.
-- `--scope related` — Current repository + all repos listed in `relates_to`.
-
----
-
-## Command Reference
-
-### `memo write` — Record a Decision
+### Intent Entry (before starting a story/task)
 
 ```bash
 memo write \
-  --rationale "Chose JWT over session cookies for stateless auth across services" \
-  --tags "auth,jwt,stateless" \
+  --rationale "Context: Starting ISSUE-<##> because <trigger>. Decision: implement via <approach>, preserving <constraints>. Impact: affects <modules/contracts>." \
+  --tags "<domain>,issue-<number>,intent,<impact-tag>" \
   --entry-type decision \
   --source agent \
+  --story "ISSUE-<number>" \
+  --on-duplicate consolidate \
   --json
 ```
 
-**Required flags:**
-
-- `--rationale` — The decision text (1–5 000 chars).
-- `--tags` — 2–5 comma-separated kebab-case tags.
-
-**Optional flags:**
-
-- `--entry-type` — `decision` (default) | `integration_point` | `structure`
-- `--source` — `agent` | `manual` (falls back to config default)
-- `--commit` — Git commit SHA for traceability
-- `--story` — Story or task ID
-- `--files` — Comma-separated file paths touched by the decision
-- `--relates-to` — Related repo names
-- `--on-duplicate` — `consolidate` | `update` | `replace` | `create-new`
-- `--json` — Machine-readable output (**always use in agent mode**)
-
-**Duplicate handling:**
-When memo detects a duplicate (same `repo + commit + story + entry_type + source`), interactive mode prompts for resolution. In `--json` mode you **MUST** supply `--on-duplicate` or the command will fail.
-
----
-
-### `memo search` — Semantic Search
-
-```bash
-memo search "rate limiting strategy" --limit 5 --json
-```
-
-Natural-language vector search over decision entries.
-
-**Optional flags:**
-
-- `--scope` — `repo` (default) | `related`
-- `--tags` — Comma-separated filter (AND logic)
-- `--entry-type` — Filter by type
-- `--source` — Filter by source
-- `--limit` — Max results (default 10)
-- `--json` — Machine-readable output
-
----
-
-### `memo list` — Chronological Browse
-
-```bash
-memo list --limit 20 --json
-```
-
-Most-recent-first listing with optional date range.
-
-**Optional flags:**
-
-- `--scope`, `--tags`, `--entry-type`, `--source` — Same as search
-- `--from` / `--to` — ISO 8601 date boundaries
-- `--limit` — Max results (default 20)
-- `--json` — Machine-readable output
-
----
-
-### `memo tags list` — Discover Tags
-
-```bash
-memo tags list --sort frequency --json
-```
-
-Shows all unique tags with entry counts.
-
-**Optional flags:**
-
-- `--scope` — `repo` | `related`
-- `--sort` — `alpha` (default) | `frequency`
-- `--json` — Machine-readable output
-
----
-
-### `memo inspect` — Global Facet Discovery
-
-```bash
-memo inspect --json
-```
-
-Lists all organizations, repositories, and domains across the entire knowledge base (ignores repo scope). Useful for onboarding and cross-team exploration.
-
-**Optional flags:**
-
-- `--orgs` / `--repos` / `--domains` — Show only one facet
-- `--json` — Machine-readable output
-
----
-
-### `memo delete` — Remove Entries
-
-**Single entry:**
-
-```bash
-memo delete --id <uuid> --json
-```
-
-**Bulk (interactive only — blocked in `--json` mode for safety):**
-
-```bash
-memo delete --all-by-repo <repo-name> --yes
-memo delete --all-by-org <org-name> --yes
-```
-
-Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
-
----
-
-## Agent Workflows
-
-### Starting a Session — Restore Context
-
-At the **beginning of every session**, run this sequence before writing a single line of code:
-
-```bash
-# 1. Confirm config is valid
-memo setup validate
-
-# 2. Discover what repos/orgs/domains exist
-memo inspect --json
-
-# 3. Review recent decisions for this repo
-memo list --limit 20 --json
-
-# 4. Check the established tag vocabulary
-memo tags list --sort frequency --json
-
-# 5. Search for context relevant to the current task
-memo search "<current task or feature description>" --limit 10 --json
-```
-
-Read the results before proceeding. Prior entries may contain constraints, preferred patterns, or rejected alternatives that directly affect how you should approach the current task.
-
----
-
-### Recording Decisions — As You Work, Not Only at the End
-
-Write a memo entry **at the moment you make a decision**, not as a post-hoc summary. This preserves the full reasoning before context is lost.
-
-**Template:**
+### Outcome Entry (after completing a story/task)
 
 ```bash
 memo write \
-  --rationale "CONTEXT. DECISION. RATIONALE." \
-  --tags "tag1,tag2,tag3" \
+  --rationale "Context: Completed ISSUE-<##>. Delivery: shipped <behavior>, deviations <none|details>, AC <x/y> verified. Impact: quality gates test=<p/f>; lint=<p/f>; format:check=<p/f>; typecheck=<p/f>; audit=<p/f>." \
+  --tags "<domain>,issue-<number>,outcome,gates-pass" \
   --entry-type decision \
   --source agent \
   --commit "$(git rev-parse HEAD)" \
-  --story "ISSUE-42" \
-  --files "path/to/file1.ts,path/to/file2.ts" \
+  --story "ISSUE-<number>" \
+  --files "<key files modified>" \
+  --on-duplicate consolidate \
   --json
 ```
 
-The `--rationale` field is the most important field. See **Writing Quality** below.
-
----
-
-### Recording File Changes — Explain the Why
-
-When modifying a significant file (entry point, core abstraction, schema, config), record what changed and why:
+### Decision Entry (architectural choices)
 
 ```bash
 memo write \
-  --rationale "Modified src/lib/config.ts to add schema_version validation. The config loader previously accepted any object; adding Zod validation ensures CLI commands fail fast on malformed configs rather than producing silent errors downstream." \
-  --tags "config,validation,config-ts,error-handling" \
-  --entry-type decision \
-  --source agent \
-  --commit "$(git rev-parse HEAD)" \
-  --files "src/lib/config.ts,src/types/config.ts" \
-  --json
-```
-
----
-
-### Recording Configuration Decisions
-
-Configuration decisions are especially important to preserve — they often appear opaque later with no obvious rationale in the code.
-
-```bash
-memo write \
-  --rationale "Set QDRANT_COLLECTION_NAME to 'decisions' permanently rather than making it configurable. A single collection per deployment simplifies queries and access control. Multi-tenancy is achieved via repo/org payload fields, not separate collections. Reconsidering this would require a data migration." \
-  --tags "qdrant,config,multi-tenancy,collection-design" \
+  --rationale "Context: <situation>. Decision: <what was chosen>. Rationale: <why this over alternatives>." \
+  --tags "<domain>,<technology>,decision" \
   --entry-type decision \
   --source agent \
   --json
 ```
 
-Configuration decisions to always record:
+---
 
-- Environment variable semantics (what the value controls, valid ranges, defaults)
-- Feature flags and their trigger conditions
-- Schema versions and migration policies
-- Storage layout choices (collection names, index strategies, partitioning)
-- Security-related configuration (TLS, auth, CORS, rate limits)
+## Entry Types
+
+| Type | Use For |
+|------|---------|
+| `decision` | Architectural/design choices, intent, outcome |
+| `integration_point` | Cross-service contracts, API boundaries |
+| `structure` | Module layout, naming conventions |
 
 ---
 
-### Intent Entry — Narrate Before Acting
+## Tag Rules
 
-For significant tasks, write an **intent entry** before starting implementation. This creates a checkpoint that future sessions can find, and anchors the rationale for every decision that follows.
-
-```bash
-memo write \
-  --rationale "Starting implementation of story ISSUE-37: safe delete command. Approach: add a --yes flag for non-interactive confirmation, block --json with bulk delete flags (safety guard for agents), preview affected entries before deletion. No soft-delete; permanent removal via Qdrant point deletion. This matches the existing write/search command pattern." \
-  --tags "delete,safety,issue-37,intent" \
-  --entry-type decision \
-  --source agent \
-  --story "ISSUE-37" \
-  --json
-```
+- Kebab-case only: `rate-limiting` not `rateLimiting`
+- 4-5 tags per entry across layers: domain, work-item, lifecycle, impact, boundary
+- Check existing tags first: `memo tags list --sort frequency --json`
+- Reuse over inventing new tags
 
 ---
 
-### Outcome Entry — Summarize After Completing
+## When to Write
 
-When finishing a task, write an **outcome entry** that captures what actually happened vs. what was intended:
-
-```bash
-memo write \
-  --rationale "Completed ISSUE-37 safe delete command. Shipped: --id single delete, --all-by-repo and --all-by-org bulk delete (interactive only), --yes to skip confirm, preview before deletion. Deviation from intent: bulk delete also disallowed with --json (not just flagged) after discovering Qdrant batch delete has no confirmation step. Modified: src/commands/delete.ts (new), tests/unit/commands/delete.test.ts (new)." \
-  --tags "delete,safety,issue-37,outcome" \
-  --entry-type decision \
-  --source agent \
-  --story "ISSUE-37" \
-  --files "src/commands/delete.ts,tests/unit/commands/delete.test.ts" \
-  --json
-```
+- Choosing a library, framework, or architecture pattern
+- Changing config files (explain why)
+- Modifying core abstractions, schemas, entry points
+- Establishing naming/layout conventions
+- Discovering constraints (API limits, platform quirks)
+- Starting/completing a story (intent/outcome)
 
 ---
 
-## Writing Quality
+## When to Search
 
-The `--rationale` field must be **precise enough that a different developer or agent — with no prior context — can understand what was decided, why, and what it affects.** A good entry answers three questions:
-
-1. **Context** — What is the situation, constraint, or problem?
-2. **Decision** — What was chosen or done?
-3. **Rationale** — Why this choice over the alternatives?
-
-### Good vs. Bad Examples
-
-**Too vague — useless to a future reader:**
-
-> "Updated auth to use JWT."
-
-**Precise — useful across sessions and developers:**
-
-> "Switched authentication from server-side sessions to JWT (HS256, 15-min access + 7-day refresh). Sessions required sticky routing which is incompatible with the planned horizontal scaling. JWTs are stateless — any instance can validate without a shared session store. Trade-off: revocation requires a Redis blacklist (added to ISSUE-51 backlog). Files: src/auth/jwt.ts, src/middleware/auth.ts."
+- Before making design choices: `memo search "<topic>" --json`
+- Before touching unfamiliar files: `memo search "<filename>" --json`
+- Cross-repo context: `memo search "<query>" --scope related --json`
 
 ---
 
-**Too vague:**
+## Agent Mode Rules
 
-> "Changed config validation."
-
-**Precise:**
-
-> "Added Zod validation to memo.config.json loader (src/lib/config.ts). Previously the code trusted the file's shape; malformed configs caused cryptic runtime errors deep in Qdrant queries. Now the CLI fails immediately at startup with a structured error message. This is the single place config is read — no other validation needed."
-
----
-
-**Too vague:**
-
-> "Used Redis for caching."
-
-**Precise:**
-
-> "Chose Redis (via ioredis) over in-process LRU cache for rate-limit counters. In-process cache doesn't survive pod restarts and is not shared across replicas. Redis TTL natively aligns with the sliding window algorithm. Accepted dependency: Redis must be available in all environments. Config: REDIS_URL env var, no auth in dev, TLS required in prod."
+- Always pass `--json` for parseable output
+- Always pass `--on-duplicate consolidate` for writes
+- Never log API keys or secrets
+- Bulk delete is blocked in `--json` mode (safety guard)
 
 ---
 
-### Structural Rule
-
-Write `--rationale` as a single coherent paragraph (or 2-3 short sentences). **Avoid bullet points** in the rationale field — they fragment reasoning and lose connective logic. Save structure for tags.
-
-Minimum viable rationale: **context sentence + decision sentence + why sentence**.
-
----
-
-## Tag Strategy
-
-Tags are the primary way to discover entries. Good tagging makes the difference between a searchable knowledge base and an unsearchable archive.
-
-### Tag Layers
-
-Apply tags across **multiple layers** simultaneously:
-
-| Layer              | Purpose                 | Examples                                               |
-| ------------------ | ----------------------- | ------------------------------------------------------ |
-| **Domain/feature** | What area of the system | `auth`, `rate-limiting`, `config`, `delete`, `storage` |
-| **Technology**     | What tech is involved   | `qdrant`, `redis`, `openai`, `zod`, `jwt`              |
-| **Entry nature**   | What kind of change     | `intent`, `outcome`, `constraint`, `trade-off`, `adr`  |
-| **Story/task ref** | Traceability            | `issue-37`, `story-s003`, `prd-001`                    |
-| **Scope**          | How broad the impact    | `cross-repo`, `breaking-change`, `config-change`       |
-
-Every write SHOULD include tags from at least **2–3 layers**.
-
-### Before Inventing a Tag — Check What Exists
-
-```bash
-memo tags list --sort frequency --json
-```
-
-Re-use existing tags whenever possible. Consistent vocabulary is what allows `memo search` to surface related entries from weeks ago or from a different repository.
-
-### Tag Naming Rules
-
-- Kebab-case only: `rate-limiting`, not `rateLimiting` or `rate_limiting`.
-- Prefer specific over generic: `qdrant-collection` over `database`.
-- For story/task refs: `issue-37`, `story-s003` (numeric, no spaces).
-- Session markers: `intent` (beginning of task) and `outcome` (completion).
-- For cross-cutting concerns: `breaking-change`, `security`, `performance`, `config-change`.
-
-### Tag Examples by Scenario
-
-**Architectural decision on storage:**
+## Quick Command Card
 
 ```
-qdrant,collection-design,multi-tenancy,decision,adr
-```
-
-**Config change:**
-
-```
-config,env-vars,config-change,issue-42
-```
-
-**Integration contract between two services:**
-
-```
-api-contract,auth-service,cross-repo,integration-point,breaking-change
-```
-
-**Starting a new feature (intent):**
-
-```
-delete-command,safety,issue-37,intent
-```
-
-**Completing a feature (outcome):**
-
-```
-delete-command,safety,issue-37,outcome
-```
-
-**Performance trade-off:**
-
-```
-embeddings,openai,performance,trade-off,caching
-```
-
----
-
-## Multi-Developer & Cross-Session Context
-
-`memo-cli` is designed so that **every agent and every developer shares the same decision history**. This is what enables continuity across days, team rotations, and parallel workstreams.
-
-### Shared Knowledge Base
-
-All entries are stored in a shared Qdrant instance. When Developer A (or Agent A) records a decision, Developer B can immediately find it via `memo search`. There is no per-user silo.
-
-### Cross-Repository Visibility
-
-Use `--scope related` to query across connected repositories:
-
-```bash
-memo search "auth contract" --scope related --json
-```
-
-This is critical for:
-
-- Microservice architectures where contracts span repos.
-- Agent workflows that touch multiple repositories in sequence.
-- Detecting when a decision in one repo contradicts a constraint in another.
-
-Configure related repos in `memo.config.json`:
-
-```json
-{
-  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
-}
-```
-
-### Session Continuity for Agents
-
-Agents are stateless between sessions. To maintain continuity:
-
-1. **Start every session** with `memo list` and `memo search` — always.
-2. **Write an intent entry** before starting significant work.
-3. **Write as you decide**, not as a batch at the end.
-4. **Write an outcome entry** when completing a task, including any deviations from intent.
-5. **Tag consistently** — check `memo tags list` before picking tags.
-
-### Multi-Day Work Pattern
-
-For work that spans multiple days:
-
-- **Day 1 end**: Write an outcome entry with current state, what's done, what's next, any open questions.
-- **Day 2 start**: `memo search "<task name or issue number>" --json` to restore exact context.
-- The tags `intent` and `outcome` combined with a story tag (e.g., `issue-37`) make the full arc of a feature retrievable as a timeline.
-
-### What to Record vs. What to Skip
-
-| Record                                        | Skip                                                        |
-| --------------------------------------------- | ----------------------------------------------------------- |
-| Architectural choices and their rationale     | Trivial implementation details (variable names, formatting) |
-| Technology selections with trade-off analysis | Routine bug fixes with no design impact                     |
-| Configuration changes that affect behavior    | Code style choices (use linters)                            |
-| API contracts and integration boundaries      | Dependency version bumps (use lockfile)                     |
-| Security-sensitive design choices             | Temporary workarounds expected to be removed within hours   |
-| Performance trade-offs and their context      | Generated code                                              |
-| Rejected alternatives and why                 | CI/build configuration (use config files)                   |
-| Constraints discovered during implementation  | Debugging steps                                             |
-
----
-
-## Memory Scopes (IDE / Agent Memory vs. memo-cli)
-
-Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each prevents both redundancy and gaps.
-
-| Scope                 | Where                  | Persistence                                    | Use For                                                                                     |
-| --------------------- | ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **User memory**       | `/memories/`           | All workspaces, all sessions                   | Personal preferences, debugging patterns, general agent insights                            |
-| **Session memory**    | `/memories/session/`   | Current conversation only                      | Scratch notes, in-progress state, temporary checklists                                      |
-| **Repository memory** | `/memories/repo/`      | Current workspace                              | Repo gotchas, build commands, local conventions — fast-access notes for this repo           |
-| **memo-cli**          | Qdrant (shared remote) | Permanent, shared across all people and agents | Architectural decisions, integration contracts, structural choices, configuration rationale |
-
-### Decision Tree: Where Does This Information Belong?
-
-```
-Is it a decision, rationale, constraint, contract, or config choice?
-  └─ YES → memo write  (it belongs to the shared knowledge base)
-
-Is it a repo-specific gotcha or quick operational fact?
-  └─ YES → /memories/repo/ (and also memo write if it reflects a real design choice)
-
-Is it a personal preference or general agent pattern?
-  └─ YES → /memories/ (user memory)
-
-Is it temporary context that only matters for the current session?
-  └─ YES → /memories/session/
-```
-
-**Key principle:** If the information would help a _different_ developer or agent working in the same codebase — even a year from now — it belongs in `memo-cli`.
-
----
-
-## Safe Operation Guardrails
-
-### Non-Destructive Defaults
-
-- `memo delete` requires confirmation by default. Use `--yes` to skip only when you are certain.
-- Bulk delete (`--all-by-repo`, `--all-by-org`) is **blocked in `--json` mode** as a safety guard against accidental mass deletion by agents.
-- `memo write` detects duplicates and prompts for resolution rather than silently overwriting.
-
-### Agent Mode (`--json`)
-
-Agents **SHOULD** always pass `--json` for predictable, parseable output. Key behaviors in JSON mode:
-
-- All output is structured JSON on stdout.
-- Errors produce JSON error objects to stderr.
-- Interactive prompts are suppressed — flags must supply all decisions.
-- `--on-duplicate` is required when a duplicate is detected.
-- Bulk delete is prohibited.
-
-### Validation Before Writing
-
-Before `memo write`, agents SHOULD:
-
-1. Verify `memo setup validate` passes.
-2. Confirm tags are kebab-case (lowercase, hyphens only).
-3. Ensure rationale is meaningful (not placeholder text).
-4. Check for duplicates with `memo search` first.
-
-### Error Handling
-
-All `memo` commands exit with:
-
-- **0** — Success
-- **1** — Validation or user error (bad flags, invalid config)
-- **2** — Unexpected/infrastructure error (Qdrant down, embedding API failure)
-
-When a command fails:
-
-1. Read the error code and message from stderr.
-2. For exit code 1: fix the input and retry.
-3. For exit code 2: check connectivity (`QDRANT_URL`) and API keys before retrying.
-
-### Environment Variable Safety
-
-- **Never** log or output `EMBEDDINGS_API_KEY` or `QDRANT_API_KEY`.
-- Store credentials in `.env` (which should be in `.gitignore`).
-- For CI/CD, use secrets management rather than plaintext config.
-
----
-
-## Quick Reference Card
-
-```
-memo setup init --repo <r> --org <o> --domain <d>   # Initialize config
 memo setup validate                                   # Verify config
-memo setup show [--json]                              # Display config
-
-memo write --rationale "..." --tags "a,b,c" [--json]  # Record decision
-memo search "query" [--scope related] [--json]         # Semantic search
-memo list [--from DATE] [--to DATE] [--json]           # Browse entries
-memo tags list [--sort frequency] [--json]             # Discover tags
-memo inspect [--json]                                  # Global facets
-memo delete --id <uuid> [--json]                       # Delete entry
+memo write --rationale "..." --tags "a,b,c" --json    # Record decision
+memo search "query" [--scope related] --json          # Semantic search
+memo list [--limit N] --json                          # Browse recent
+memo tags list [--sort frequency] --json              # Discover tags
+memo inspect --json                                   # Global facets
+memo delete --id <uuid> --json                        # Delete entry
 ```
 
----
-
-## Installation in Another Repository
-
-1. **Copy** the `memo-cli-usage/` folder into `<your-repo>/.github/skills/`.
-2. **Add** the skill to your agent/skill registry (e.g., `AGENTS.md`):
-   ```markdown
-   | memo-cli-usage | `.github/skills/memo-cli-usage/` | Agent guidance for memo-cli operations | Any agent |
-   ```
-3. **Install** `memo-cli` as a dev dependency:
-   ```bash
-   pnpm add -D memo-cli   # or npm install -D memo-cli
-   ```
-4. **Configure** the repository:
-   ```bash
-   npx memo setup init --repo <name> --org <org> --domain <domain>
-   ```
-5. **Set** environment variables (`.env` or CI secrets):
-   ```
-   QDRANT_URL=http://localhost:6333
-   QDRANT_API_KEY=
-   EMBEDDINGS_PROVIDER=openai
-   EMBEDDINGS_API_KEY=sk-...
-   ```
-6. The skill is now active — any agent that loads it will know how to use `memo-cli`.
+> For full flag documentation, admin operations, environment setup, and detailed examples, read [`REFERENCE.md`](./REFERENCE.md).

--- a/.kiro/steering/git-guard-notice.md
+++ b/.kiro/steering/git-guard-notice.md
@@ -2,15 +2,9 @@
 inclusion: always
 ---
 
-# Kiro Guard Hook — Enforcement Gap Disclosure
-
-This repository ships `.kiro/hooks/git-guard.json` + `.kiro/hooks/scripts/git-guard.sh` as a best-effort port of Claude Code's `.claude/hooks/git-guard.sh`, enforcing two invariants:
+# Git Guard — Two Invariants
 
 1. No agent may push or merge into the default branch `main`.
 2. `git commit` messages must follow Conventional Commits.
 
-**This hook is not guaranteed to be equivalent to Claude Code's `git-guard.sh`.** Kiro's `PreToolUse` hook trigger uses the same exit-code-2 blocking contract as Claude Code's, so blocking is architecturally possible — but a tracked upstream defect (kirodotdev/Kiro#7375) has been reported where Kiro IDE's `PreToolUse` hooks receive an empty `toolArgs` object, unlike the Kiro CLI which passes full context. If that defect affects this environment, the hook cannot see the actual command text and therefore cannot reliably block anything, even though it fires on the right event.
-
-When the hook cannot see command context, it **fails loud, not silent**: it prints a warning to stderr rather than allowing the command through without a trace. Watch Kiro's hook run history for these warnings — they mean the guard could not evaluate the command.
-
-**Until this is verified fixed on a live Kiro install, treat human PR review as the actual enforcement backstop for the `main`-merge and commit-convention rules on Kiro** — do not rely on this hook alone the way you can rely on `.claude/hooks/git-guard.sh` in Claude Code.
+**Enforcement backstop:** Treat human PR review as the actual gate for these rules on Kiro. The hook (`.kiro/hooks/git-guard.json`) is best-effort due to a known upstream limitation.

--- a/.kiro/steering/implement.md
+++ b/.kiro/steering/implement.md
@@ -1,5 +1,6 @@
 ---
-inclusion: always
+inclusion: fileMatch
+fileMatchPattern: "workstream/**/tasks-*.md"
 ---
 
 # Activity: Implement Task List

--- a/.kiro/steering/nextjs-pages-components.md
+++ b/.kiro/steering/nextjs-pages-components.md
@@ -1,7 +1,9 @@
 ---
 inclusion: fileMatch
-fileMatchPattern: "**/*.tsx"
+fileMatchPattern: "**/app/**/*.tsx"
 ---
+
+<!-- Consumers: adjust fileMatchPattern to match your Next.js app path. For React Native projects, replace with a react-native steering file (see issue #13). -->
 
 # Rule: Keep Next.js Pages and React Components Consistent
 

--- a/.kiro/steering/plan.md
+++ b/.kiro/steering/plan.md
@@ -1,5 +1,6 @@
 ---
-inclusion: always
+inclusion: fileMatch
+fileMatchPattern: "workstream/**"
 ---
 
 # Activity: Plan Implementation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,11 +101,11 @@ Instructions are scoped via `applyTo` and auto-applied. Only cross-cutting rules
 
 > **Available for:** Copilot (`.github/instructions/*.instructions.md`, scoped via `applyTo`), Claude Code (`plan` and `implement` are on-demand skills instead of always-loaded instructions), Kiro (`.kiro/steering/*.md`, called "steering" and scoped via `inclusion: always|fileMatch` + `fileMatchPattern`, the Kiro analogue of `applyTo`). Kiro's steering set has a 4th file, `git-guard-notice.md` (`inclusion: always`), with no equivalent on Copilot or Claude Code — it discloses a Kiro-specific hook enforcement gap.
 
-| Instruction                 | File                                             | Scope      | Purpose                                                                  |
-| --------------------------- | ------------------------------------------------ | ---------- | ------------------------------------------------------------------------ |
-| **plan**                    | `plan.instructions.md`                           | `**`       | Convert stories or refined issues into execution-ready task lists        |
-| **implement**               | `implement.instructions.md`                      | `**`       | Execute task list with step-gated approval, branching, and PR discipline |
-| **nextjs-pages-components** | `domain/nextjs-pages-components.instructions.md` | `**/*.tsx` | Next.js + React conventions                                              |
+| Instruction                 | File                                             | Scope                       | Purpose                                                                  |
+| --------------------------- | ------------------------------------------------ | --------------------------- | ------------------------------------------------------------------------ |
+| **plan**                    | `plan.instructions.md`                           | `workstream/**`             | Convert stories or refined issues into execution-ready task lists        |
+| **implement**               | `implement.instructions.md`                      | `workstream/**/tasks-*.md`  | Execute task list with step-gated approval, branching, and PR discipline |
+| **nextjs-pages-components** | `domain/nextjs-pages-components.instructions.md` | `**/app/**/*.tsx`           | Next.js + React conventions                                              |
 
 ## Prompts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,23 +28,15 @@ If `/DESIGN.md` is missing and the requested scope includes UI work, agents **MU
 
 ## Taxonomy: Agent vs Skill vs Instruction
 
-| Concept         | Purpose                                                                                                                                    | Loaded When                            | Decision Rule                                                                               |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **Agent**       | Autonomous role with decision-making, phases, and handoff discipline. Owns a workflow end-to-end.                                          | Invoked by name (`@agent`)             | "Does it make decisions, own a multi-phase workflow, and hand off to other agents?" → Agent |
-| **Skill**       | Reusable on-demand capability. Describes _procedures_ or _activities_ that any agent can invoke when needed. Not loaded unless referenced. | On demand (invoked by agent or prompt) | "Is this capability needed only sometimes, by one or more agents?" → Skill                  |
-| **Instruction** | Always-loaded rule scoped via `applyTo` frontmatter. Enforced automatically for every matching context.                                    | Always (auto-applied by runtime)       | "Must this rule be enforced every time, for every matching file or context?" → Instruction  |
-
-**Key distinctions:**
-
-- Skills save context window space — they are loaded only when invoked, unlike instructions which are always present.
-- Agent files define _who_ (identity, phases, handoff rules). Skill files define _how_ (procedures, templates, steps).
-- Instructions are for cross-cutting rules that must never be forgotten (e.g., implementation discipline, planning format).
+| Concept         | Purpose                                                              | Loaded When                      |
+| --------------- | -------------------------------------------------------------------- | -------------------------------- |
+| **Agent**       | Autonomous role with decision-making and handoff discipline          | Invoked by name (`@agent`)       |
+| **Skill**       | Reusable on-demand capability (procedures/activities)                | On demand (invoked by agent)     |
+| **Instruction** | Scoped rule enforced automatically for matching context              | Auto-applied by runtime          |
 
 ---
 
 ## Agents
-
-> **Available for:** Copilot (`.github/agents/`), Claude Code (`.claude/agents/`), Kiro (`.kiro/agents/`). All three platforms define the same 8 agents below. On Kiro, each agent file also embeds an "Invocation Modes" section in place of separate prompt files (see [Prompts](#prompts)).
 
 | Agent                | File                        | Purpose                                                                                                                                                                                                                                          |
 | -------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -59,13 +51,9 @@ If `/DESIGN.md` is missing and the requested scope includes UI work, agents **MU
 
 ## Skills
 
-Skills are on-demand capabilities invoked by agents. They are **not** loaded into context unless explicitly referenced.
-
-> **Available for:** Copilot (`.github/skills/<name>/SKILL.md`), Claude Code (`.claude/skills/<name>/SKILL.md`), Kiro (`.kiro/skills/<name>/SKILL.md`). Same skill set on all three platforms.
+Skills are on-demand capabilities invoked by agents — **not** loaded unless explicitly referenced.
 
 ### Activity Skills
-
-These are the composable activities from the development workflow, converted to skills so they only consume context when needed:
 
 | Skill                             | Directory                               | Purpose                                                                                                                           | Primary Consumer   |
 | --------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
@@ -95,11 +83,9 @@ These are the composable activities from the development workflow, converted to 
 | **vercel-composition-patterns** | `skills/vercel-composition-patterns/` | Vercel component composition patterns | `developer`, `ux-engineer` |
 | **vercel-react-best-practices** | `skills/vercel-react-best-practices/` | Vercel React best practices           | `developer`, `ux-engineer` |
 
-## Instructions (Always-Loaded)
+## Instructions (Scoped)
 
-Instructions are scoped via `applyTo` and auto-applied. Only cross-cutting rules that must always be enforced remain as instructions.
-
-> **Available for:** Copilot (`.github/instructions/*.instructions.md`, scoped via `applyTo`), Claude Code (`plan` and `implement` are on-demand skills instead of always-loaded instructions), Kiro (`.kiro/steering/*.md`, called "steering" and scoped via `inclusion: always|fileMatch` + `fileMatchPattern`, the Kiro analogue of `applyTo`). Kiro's steering set has a 4th file, `git-guard-notice.md` (`inclusion: always`), with no equivalent on Copilot or Claude Code — it discloses a Kiro-specific hook enforcement gap.
+Instructions are scoped via `applyTo`/`fileMatchPattern` and auto-applied to matching files.
 
 | Instruction                 | File                                             | Scope                       | Purpose                                                                  |
 | --------------------------- | ------------------------------------------------ | --------------------------- | ------------------------------------------------------------------------ |
@@ -109,88 +95,7 @@ Instructions are scoped via `applyTo` and auto-applied. Only cross-cutting rules
 
 ## Prompts
 
-Prompts are entry points that configure an agent for a specific use case.
-
-> **Available for:** Copilot (`.github/prompts/*.prompt.md`), Claude Code (`.claude/commands/*.md`, invoked with `/command-name`). Kiro has no separate "prompts" concept — the invocation modes below are folded directly into the corresponding `.kiro/agents/*.md` file as an "Invocation Modes" section instead of standalone files.
-
-| Prompt                     | Agent            | Purpose                                                                                         |
-| -------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
-| `product-engineer-init`    | product-engineer | Initialize project foundation documents                                                         |
-| `product-engineer-feature` | product-engineer | Design and plan a new feature end-to-end                                                        |
-| `product-engineer-issue`   | product-engineer | Refine and plan a GitHub Issue                                                                  |
-| `developer-execute`        | developer        | Execute an existing task list                                                                   |
-| `planner`                  | planner          | Orchestrate multi-story execution                                                               |
-| `planner-resume`           | planner          | Resume interrupted multi-story run from checkpoint                                              |
-| `ux-engineer`              | ux-engineer      | Generate UX mockups from PRD/SPEC                                                               |
-| `github-ops`               | github-ops       | GitHub consistency operations                                                                   |
-| `technical-writer`         | technical-writer | Documentation maintenance                                                                       |
-| `housekeeping`             | housekeeping     | Lint, type, and test fixes                                                                      |
-| `verifier-design`          | verifier         | Generate compliance test plan from spec or stories (Design Mode)                                |
-| `verifier-audit`           | verifier         | Grey-box fidelity audit of delivered work against spec/stories and PRD/spec intent (Audit Mode) |
-
----
-
-## Workflow Chains
-
-### Full Feature (PRD-Driven)
-
-```text
-product-engineer: refine → generate-spec → generate-stories → publish-github → plan
-                                                                                  ↓
-developer: implement
-```
-
-### Single GitHub Issue
-
-```text
-product-engineer: refine → plan
-                            ↓
-developer: implement
-```
-
-### Multi-Story Orchestration
-
-```text
-product-engineer: refine → generate-spec → generate-stories → publish-github → plan
-                                                                                  ↓
-planner: orchestrate → developer: implement (per story, sequential)
-```
-
-### Quick Fix (Clear Issue, Task List Exists)
-
-```text
-developer: implement
-```
-
-### UX Validation Loop
-
-```text
-product-engineer: refine → generate-spec
-                               ↓
-ux-engineer: mockups → gap analysis → refinement handoff
-                                          ↓
-product-engineer: update spec/stories
-```
-
-### Test-First Design (Verifier)
-
-```text
-product-engineer: refine → spec → stories → plan
-                                                 ↓
-verifier (design mode): generate test plan (from spec or stories)
-                                                 ↓
-developer/planner: implement (feature + tests from test plan)
-                        ↓ (automatic, mandatory, non-skippable)
-                    verifier (audit mode): grey-box fidelity audit → fidelity report
-                        ↓ (drift findings, non-blocking)
-                    product-engineer: activity-drift-reconciliation
-```
-
-### Project Initialization
-
-```text
-product-engineer (init mode): activity-init → product-context.md + technical-guidelines.md
-```
+See individual agent files for invocation modes and entry points. Reference: Copilot (`.github/prompts/`), Claude Code (`.claude/commands/`), Kiro (embedded in `.kiro/agents/`).
 
 ---
 
@@ -204,12 +109,12 @@ All AI coding agents working in this repository **MUST**:
 - **PRs targeting `main` require user approval** — no agent may merge into the default branch
 - Follow testing, linting, and documentation standards from `technical-guidelines.md`
 - Reference GitHub Issues in branch names and commits
-- Maintain document changelogs when updating generated artifacts (PRDs, specs, user stories, etc.)
-- Treat `/DESIGN.md` as the source of truth for visual tokens, components, and design guidance; update it whenever UI contracts change
-- Prefer `pnpm` over `npm` for JavaScript/TypeScript workflows (fallback to `npm` only when `pnpm` is unavailable or explicitly disallowed)
-- Use canonical `package.json` script names for JS/TS projects: `lint`, `lint:fix`, `format`, `format:check`, `typecheck`, `test`, `test:unit`, `test:integration`, `test:e2e`, `audit`, `validate`
-- Before developer/planner completion, enforce quality gates with recorded evidence: `test`, `lint`, `format:check`, `typecheck`, `audit`
+- Treat `/DESIGN.md` as the source of truth for visual tokens, components, and design guidance
+- Prefer `pnpm` over `npm` for JS/TS workflows
+- Use canonical script names: `lint`, `format:check`, `typecheck`, `test`, `audit`, `validate`
+- Enforce quality gates before completion: `test`, `lint`, `format:check`, `typecheck`, `audit`
 - Use the `git-ops` skill for branch management, rebase, and conflict resolution
-- If `memo-cli` is installed and `memo setup validate` passes: `product-engineer` **MUST** read from memo at session start; `developer` **MUST** write intent and outcome entries per story; `technical-writer` **MUST** write one memo entry per ADR created and per significant doc change
-- If `memo-cli` is installed but not configured (validation fails), ask the user to run `memo setup init` before proceeding with memo operations
-- The `verifier` audit (`audit` mode) is a mandatory, non-skippable step triggered automatically by `developer` (per issue, pre-PR-ready) and `planner` (per story and PRD-level rollup) — it is never optional and never manually invoked as a substitute for this automatic trigger. Drift findings from this audit are non-blocking to PR/issue completion and are routed to `product-engineer`'s `activity-drift-reconciliation` skill for write-back.
+- The `verifier` audit is mandatory and non-skippable before every PR is marked ready. Drift findings are non-blocking and route to `product-engineer`'s `activity-drift-reconciliation`.
+- If `memo-cli` is installed and configured: agents **MUST** read/write entries per their role (see agent files for details)
+
+For workflow chains and sequencing diagrams, see [`docs/workflow-chains.md`](docs/workflow-chains.md).

--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -1,6 +1,8 @@
 
 # dev-tasks
 
+> **Sizing guidance:** See [`docs/agents-md-guidelines.md`](docs/agents-md-guidelines.md) for recommended AGENTS.md size and content rules.
+
 A set of agents, skills, and instructions for GitHub Copilot, Claude Code, Kiro, and other AI coding agents to run structured, PRD-driven development workflows.
 
 ## Core Idea
@@ -29,22 +31,15 @@ If `/DESIGN.md` is missing and the requested scope includes UI work, agents **MU
 
 ## Taxonomy: Agent vs Skill vs Instruction
 
-| Concept | Purpose | Loaded When | Decision Rule |
-|---------|---------|-------------|---------------|
-| **Agent** | Autonomous role with decision-making, phases, and handoff discipline. Owns a workflow end-to-end. | Invoked by name (`@agent`) | "Does it make decisions, own a multi-phase workflow, and hand off to other agents?" → Agent |
-| **Skill** | Reusable on-demand capability. Describes *procedures* or *activities* that any agent can invoke when needed. Not loaded unless referenced. | On demand (invoked by agent or prompt) | "Is this capability needed only sometimes, by one or more agents?" → Skill |
-| **Instruction** | Always-loaded rule scoped via `applyTo` frontmatter. Enforced automatically for every matching context. | Always (auto-applied by runtime) | "Must this rule be enforced every time, for every matching file or context?" → Instruction |
-
-**Key distinctions:**
-- Skills save context window space — they are loaded only when invoked, unlike instructions which are always present.
-- Agent files define *who* (identity, phases, handoff rules). Skill files define *how* (procedures, templates, steps).
-- Instructions are for cross-cutting rules that must never be forgotten (e.g., implementation discipline, planning format).
+| Concept | Purpose | Loaded When |
+|---------|---------|-------------|
+| **Agent** | Autonomous role with decision-making and handoff discipline | Invoked by name (`@agent`) |
+| **Skill** | Reusable on-demand capability (procedures/activities) | On demand (invoked by agent) |
+| **Instruction** | Scoped rule enforced automatically for matching context | Auto-applied by runtime |
 
 ---
 
 ## Agents
-
-> **Available for:** Copilot (`.github/agents/`), Claude Code (`.claude/agents/`), Kiro (`.kiro/agents/`). All three platforms define the same 8 agents below. On Kiro, each agent file also embeds an "Invocation Modes" section in place of separate prompt files (see [Prompts](#prompts)).
 
 | Agent | File | Purpose |
 |---|---|---|
@@ -59,13 +54,9 @@ If `/DESIGN.md` is missing and the requested scope includes UI work, agents **MU
 
 ## Skills
 
-Skills are on-demand capabilities invoked by agents. They are **not** loaded into context unless explicitly referenced.
-
-> **Available for:** Copilot (`.github/skills/<name>/SKILL.md`), Claude Code (`.claude/skills/<name>/SKILL.md`), Kiro (`.kiro/skills/<name>/SKILL.md`). Same skill set on all three platforms.
+Skills are on-demand capabilities invoked by agents — **not** loaded unless explicitly referenced.
 
 ### Activity Skills
-
-These are the composable activities from the development workflow, converted to skills so they only consume context when needed:
 
 | Skill | Directory | Purpose | Primary Consumer |
 |---|---|---|---|
@@ -95,11 +86,9 @@ These are the composable activities from the development workflow, converted to 
 | **vercel-composition-patterns** | `skills/vercel-composition-patterns/` | Vercel component composition patterns | `developer`, `ux-engineer` |
 | **vercel-react-best-practices** | `skills/vercel-react-best-practices/` | Vercel React best practices | `developer`, `ux-engineer` |
 
-## Instructions (Always-Loaded)
+## Instructions (Scoped)
 
-Instructions are scoped via `applyTo` and auto-applied. Only cross-cutting rules that must always be enforced remain as instructions.
-
-> **Available for:** Copilot (`.github/instructions/*.instructions.md`, scoped via `applyTo`), Claude Code (`plan` and `implement` are on-demand skills instead of always-loaded instructions), Kiro (`.kiro/steering/*.md`, called "steering" and scoped via `inclusion: always|fileMatch` + `fileMatchPattern`, the Kiro analogue of `applyTo`). Kiro's steering set has a 4th file, `git-guard-notice.md` (`inclusion: always`), with no equivalent on Copilot or Claude Code — it discloses a Kiro-specific hook enforcement gap.
+Instructions are scoped via `applyTo`/`fileMatchPattern` and auto-applied to matching files.
 
 | Instruction | File | Scope | Purpose |
 |---|---|---|---|
@@ -109,88 +98,7 @@ Instructions are scoped via `applyTo` and auto-applied. Only cross-cutting rules
 
 ## Prompts
 
-Prompts are entry points that configure an agent for a specific use case.
-
-> **Available for:** Copilot (`.github/prompts/*.prompt.md`), Claude Code (`.claude/commands/*.md`, invoked with `/command-name`). Kiro has no separate "prompts" concept — the invocation modes below are folded directly into the corresponding `.kiro/agents/*.md` file as an "Invocation Modes" section instead of standalone files.
-
-| Prompt | Agent | Purpose |
-|---|---|---|
-| `product-engineer-init` | product-engineer | Initialize project foundation documents |
-| `product-engineer-feature` | product-engineer | Design and plan a new feature end-to-end |
-| `product-engineer-issue` | product-engineer | Refine and plan a GitHub Issue |
-| `developer-execute` | developer | Execute an existing task list |
-| `planner` | planner | Orchestrate multi-story execution |
-| `planner-resume` | planner | Resume interrupted multi-story run from checkpoint |
-| `ux-engineer` | ux-engineer | Generate UX mockups from PRD/SPEC |
-| `github-ops` | github-ops | GitHub consistency operations |
-| `technical-writer` | technical-writer | Documentation maintenance |
-| `housekeeping` | housekeeping | Lint, type, and test fixes |
-| `verifier-design` | verifier | Generate compliance test plan from spec or stories (Design Mode) |
-| `verifier-audit` | verifier | Grey-box fidelity audit of delivered work against spec/stories and PRD/spec intent (Audit Mode) |
-
----
-
-## Workflow Chains
-
-### Full Feature (PRD-Driven)
-
-```
-product-engineer: refine → generate-spec → generate-stories → publish-github → plan
-                                                                                  ↓
-developer: implement
-```
-
-### Single GitHub Issue
-
-```
-product-engineer: refine → plan
-                            ↓
-developer: implement
-```
-
-### Multi-Story Orchestration
-
-```
-product-engineer: refine → generate-spec → generate-stories → publish-github → plan
-                                                                                  ↓
-planner: orchestrate → developer: implement (per story, sequential)
-```
-
-### Quick Fix (Clear Issue, Task List Exists)
-
-```
-developer: implement
-```
-
-### UX Validation Loop
-
-```
-product-engineer: refine → generate-spec
-                               ↓
-ux-engineer: mockups → gap analysis → refinement handoff
-                                          ↓
-product-engineer: update spec/stories
-```
-
-### Test-First Design (Verifier)
-
-```
-product-engineer: refine → spec → stories → plan
-                                                 ↓
-verifier (design mode): generate test plan (from spec or stories)
-                                                 ↓
-developer/planner: implement (feature + tests from test plan)
-                        ↓ (automatic, mandatory, non-skippable)
-                    verifier (audit mode): grey-box fidelity audit → fidelity report
-                        ↓ (drift findings, non-blocking)
-                    product-engineer: activity-drift-reconciliation
-```
-
-### Project Initialization
-
-```
-product-engineer (init mode): activity-init → product-context.md + technical-guidelines.md
-```
+See individual agent files for invocation modes and entry points. Reference: Copilot (`.github/prompts/`), Claude Code (`.claude/commands/`), Kiro (embedded in `.kiro/agents/`).
 
 ---
 
@@ -204,9 +112,12 @@ All AI coding agents working in this repository **MUST**:
 - **PRs targeting `main` require user approval** — no agent may merge into the default branch
 - Follow testing, linting, and documentation standards from `technical-guidelines.md`
 - Reference GitHub Issues in branch names and commits
-- Maintain document changelogs when updating generated artifacts (PRDs, specs, user stories, etc.)
-- Treat `/DESIGN.md` as the source of truth for visual tokens, components, and design guidance; update it whenever UI contracts change
+- Treat `/DESIGN.md` as the source of truth for visual tokens, components, and design guidance
+- Prefer `pnpm` over `npm` for JS/TS workflows
+- Use canonical script names: `lint`, `format:check`, `typecheck`, `test`, `audit`, `validate`
+- Enforce quality gates before completion: `test`, `lint`, `format:check`, `typecheck`, `audit`
 - Use the `git-ops` skill for branch management, rebase, and conflict resolution
-- If `memo-cli` is installed and `memo setup validate` passes: `product-engineer` **MUST** read from memo at session start; `developer` **MUST** write intent and outcome entries per story; `technical-writer` **MUST** write one memo entry per ADR created and per significant doc change
-- If `memo-cli` is installed but not configured (validation fails), ask the user to run `memo setup init` before proceeding with memo operations
-- The `verifier` audit (`audit` mode) is a mandatory, non-skippable step triggered automatically by `developer` (per issue, pre-PR-ready) and `planner` (per story and PRD-level rollup) — it is never optional and never manually invoked as a substitute for this automatic trigger. Drift findings from this audit are non-blocking to PR/issue completion and are routed to `product-engineer`'s `activity-drift-reconciliation` skill for write-back.
+- The `verifier` audit is mandatory and non-skippable before every PR is marked ready. Drift findings are non-blocking and route to `product-engineer`'s `activity-drift-reconciliation`.
+- If `memo-cli` is installed and configured: agents **MUST** read/write entries per their role (see agent files for details)
+
+For workflow chains and sequencing diagrams, see [`docs/workflow-chains.md`](docs/workflow-chains.md).

--- a/AGENTS.md.template
+++ b/AGENTS.md.template
@@ -103,9 +103,9 @@ Instructions are scoped via `applyTo` and auto-applied. Only cross-cutting rules
 
 | Instruction | File | Scope | Purpose |
 |---|---|---|---|
-| **plan** | `plan.instructions.md` | `**` | Convert stories or refined issues into execution-ready task lists |
-| **implement** | `implement.instructions.md` | `**` | Execute task list with step-gated approval, branching, and PR discipline |
-| **nextjs-pages-components** | `domain/nextjs-pages-components.instructions.md` | `**/*.tsx` | Next.js + React conventions |
+| **plan** | `plan.instructions.md` | `workstream/**` | Convert stories or refined issues into execution-ready task lists |
+| **implement** | `implement.instructions.md` | `workstream/**/tasks-*.md` | Execute task list with step-gated approval, branching, and PR discipline |
+| **nextjs-pages-components** | `domain/nextjs-pages-components.instructions.md` | `**/app/**/*.tsx` | Next.js + React conventions |
 
 ## Prompts
 

--- a/docs/agents-md-guidelines.md
+++ b/docs/agents-md-guidelines.md
@@ -1,0 +1,63 @@
+# AGENTS.md Sizing and Content Guidelines
+
+## Purpose
+
+`AGENTS.md` is the root-level project description file that all AI coding agents read on every turn. Its content directly impacts token usage — every word costs tokens on every interaction. Keep it lean and operational.
+
+## Recommended Size
+
+- **Target:** ~1,000 words (~1,350 tokens)
+- **Maximum:** ~1,500 words (~2,000 tokens)
+- **Minimum:** ~400 words (~550 tokens) for a simple project
+
+## What Belongs in AGENTS.md
+
+Content that agents need **every turn** to make correct decisions:
+
+- Project identity and core purpose (1-2 sentences)
+- Design contract reference (`/DESIGN.md`)
+- Taxonomy (agent vs skill vs instruction) — brief definitions
+- Agent roster table (name, file, one-line purpose)
+- Skills roster table (name, directory, one-line purpose)
+- Instructions table (name, scope, purpose)
+- General agent guidelines (branch discipline, commit conventions, quality gates, merge authority)
+
+## What Does NOT Belong in AGENTS.md
+
+Content that is reference material, not operational per-turn guidance:
+
+- Workflow chain diagrams → move to `docs/workflow-chains.md`
+- Prompt/command tables → agents carry their own invocation modes
+- Detailed tool configuration → belongs in agent or skill files
+- Post-mortems and decision logs → belongs in `docs/adr/` or memo-cli
+- Setup instructions → belongs in README or `docs/`
+- Verbose explanations of concepts → belongs in `docs/`
+
+## Decision Rule
+
+Before adding content to AGENTS.md, ask:
+
+> "Does an agent need this information on **every single turn** to behave correctly?"
+
+- **Yes** → put it in AGENTS.md
+- **No, but agents need it sometimes** → put it in a skill file or docs/
+- **No, it's for humans** → put it in README, docs/, or a wiki
+
+## Generating a Right-Sized AGENTS.md
+
+Run `product-engineer init` to generate foundation documents including a properly-sized AGENTS.md for your project. The init activity will:
+
+1. Analyze your project structure
+2. Identify which agents and skills are relevant
+3. Produce an AGENTS.md that follows these sizing guidelines
+
+## Measuring Token Impact
+
+To check your AGENTS.md token cost:
+
+```bash
+# Approximate token count (words * 1.35)
+wc -w AGENTS.md
+```
+
+If your AGENTS.md exceeds 1,500 words, audit it against the "What Does NOT Belong" list above and extract reference content to `docs/`.

--- a/docs/workflow-chains.md
+++ b/docs/workflow-chains.md
@@ -1,0 +1,63 @@
+# Workflow Chains
+
+Reference documentation for how agents chain together in different scenarios.
+
+## Full Feature (PRD-Driven)
+
+```text
+product-engineer: refine → generate-spec → generate-stories → publish-github → plan
+                                                                                  ↓
+developer: implement
+```
+
+## Single GitHub Issue
+
+```text
+product-engineer: refine → plan
+                            ↓
+developer: implement
+```
+
+## Multi-Story Orchestration
+
+```text
+product-engineer: refine → generate-spec → generate-stories → publish-github → plan
+                                                                                  ↓
+planner: orchestrate → developer: implement (per story, sequential)
+```
+
+## Quick Fix (Clear Issue, Task List Exists)
+
+```text
+developer: implement
+```
+
+## UX Validation Loop
+
+```text
+product-engineer: refine → generate-spec
+                               ↓
+ux-engineer: mockups → gap analysis → refinement handoff
+                                          ↓
+product-engineer: update spec/stories
+```
+
+## Test-First Design (Verifier)
+
+```text
+product-engineer: refine → spec → stories → plan
+                                                 ↓
+verifier (design mode): generate test plan (from spec or stories)
+                                                 ↓
+developer/planner: implement (feature + tests from test plan)
+                        ↓ (automatic, mandatory, non-skippable)
+                    verifier (audit mode): grey-box fidelity audit → fidelity report
+                        ↓ (drift findings, non-blocking)
+                    product-engineer: activity-drift-reconciliation
+```
+
+## Project Initialization
+
+```text
+product-engineer (init mode): activity-init → product-context.md + technical-guidelines.md
+```

--- a/workstream/specification-token-optimization-devtasks.md
+++ b/workstream/specification-token-optimization-devtasks.md
@@ -1,0 +1,383 @@
+# Specification: Token-Usage Optimization for the dev-tasks Workflow
+
+> **Status:** Draft — ready for implementation
+> **Type:** Tooling / configuration (non-application-code)
+> **Author:** Analysis session (Kiro)
+> **Intended executor:** Any agent or developer in a fresh environment
+> **RFC 2119:** MUST / SHOULD / MAY are used with their standard meanings.
+
+---
+
+## 1. Purpose
+
+The `home-ledger` repository drives an agent workflow (planner, developer,
+product-engineer, housekeeping, technical-writer, plus activity skills) through
+three parallel definition trees (`.kiro/`, `.github/`, `.claude/`) and a set of
+Kiro steering files that are injected into model context.
+
+An analysis found that a large amount of context is injected on **every turn**
+regardless of relevance, and that several rules are mis-scoped or duplicated.
+This spec defines the concrete changes required to cut recurring token usage
+**without losing any guidance** — activity rules should load exactly when their
+artifacts are in play, not on every interaction.
+
+This spec is self-contained: it restates the findings and the exact edits so it
+can be executed in an environment that does not have access to the original
+analysis session.
+
+---
+
+## 2. Background: how tokens are consumed
+
+Two cost buckets exist:
+
+1. **Per-turn injected context** — Kiro steering files with `inclusion: always`
+   and the workspace `AGENTS.md` load into context on every turn. This is the
+   dominant recurring cost because it is multiplied by every turn in every
+   session.
+2. **On-demand context** — agent definition files and skill `SKILL.md` files
+   are read when an agent/skill is invoked. Lower recurring cost, but subject to
+   drift because the same content is triplicated.
+
+### 2.1 Measured baseline (word counts, ~tokens ≈ words × 1.35)
+
+Always-injected on every turn:
+
+| File | Words | ~Tokens | Actually relevant when |
+| --- | --- | --- | --- |
+| `AGENTS.md` | 1,792 | ~2,400 | implementation / orchestration only |
+| `.kiro/steering/plan.md` | 1,102 | ~1,500 | **plan** activity only |
+| `.kiro/steering/implement.md` | 959 | ~1,300 | **implement** activity only |
+| `.kiro/steering/git-guard-notice.md` | 225 | ~300 | git push / merge only |
+| **Always-on baseline** | **4,078** | **~5,500 / turn** | |
+
+Conditionally injected (`fileMatch`):
+
+| File | Words | ~Tokens | Current pattern |
+| --- | --- | --- | --- |
+| `.kiro/steering/nextjs-pages-components.md` | 2,292 | ~3,100 | `**/*.tsx` |
+
+Triple-maintained (on-demand, not auto-injected):
+
+| Tree | Agents (words) | Skills (words) |
+| --- | --- | --- |
+| `.kiro/` | 14,080 | 15,178 |
+| `.github/` | 13,060 | 14,924 |
+| `.claude/` | 9,134 | 17,296 |
+
+`memo-cli-usage/SKILL.md` is ~4,293 words (~5,800 tokens), roughly 4x the average
+skill.
+
+### 2.2 Key problems identified
+
+- **P1 — Mutually exclusive playbooks are both `always`.** `plan.md` and
+  `implement.md` are activity playbooks for opposite phases, yet both carry
+  `inclusion: always`. Each is paid for during the other's activity and during
+  all unrelated work (chat, debugging, analysis).
+- **P2 — Next.js steering is mis-scoped.** `nextjs-pages-components.md` is titled
+  for **Next.js** and `AGENTS.md` scopes it to `apps/management-hub/src/**/*.tsx`,
+  but its `fileMatchPattern` is the much broader `**/*.tsx`. The app
+  `apps/management-hub` does not exist; the real apps are `api`, `app` (Expo /
+  React Native), and `scraper`. So ~3,100 tokens of Next.js rules inject on
+  nearly every React Native `.tsx` edit where they do not apply.
+- **P3 — `AGENTS.md` always-on footprint is broad.** It contains per-agent
+  constraints and historical post-mortems that are only relevant when a specific
+  agent is active (and those agents already load their own definition files).
+- **P4 — Triplicated definitions.** `.kiro/steering/plan.md` is byte-identical to
+  `.github/instructions/plan.instructions.md` (front-matter aside); same for
+  `implement.md`. Agent files differ only by path references and front-matter.
+  Duplication invites drift.
+- **P5 — `memo-cli-usage` is oversized** for an on-demand skill that may be
+  invoked frequently for cross-session context.
+- **P6 — `git-guard-notice.md` is always-on** but only relevant to git
+  operations.
+
+---
+
+## 3. Scope
+
+**In scope:** Kiro steering front-matter and content, `AGENTS.md` structure,
+consolidation of duplicated definition trees, skill file splitting.
+
+**Out of scope:** Any application code under `apps/`, `packages/`, or `docs/`.
+No behavioral change to the agents themselves — only what context loads and when.
+
+**Constraint:** All guidance MUST remain reachable. The goal is *right time*,
+not *removal*. No rule text may be deleted unless it is provably dead (e.g.
+references a non-existent app) and confirmed with the user.
+
+---
+
+## 4. Requirements & Implementation Tasks
+
+Each task lists the exact file, the change, and its acceptance criteria. Tasks
+are ordered by payoff. Tasks R1 and R2 are the highest-value, lowest-risk, and
+fully reversible.
+
+### R1 — Convert activity playbooks from `always` to `fileMatch` (highest impact)
+
+**Problem:** P1. **Est. savings:** ~2,000 tokens/turn on non-activity turns.
+
+Change the front-matter of the two activity steering files so they load only
+when their working artifacts are in context. The `implement` and `plan`
+activities always operate on files under `workstream/`, so the rules still load
+exactly when needed.
+
+- File: `.kiro/steering/plan.md`
+  - Current front-matter:
+    ```yaml
+    ---
+    inclusion: always
+    ---
+    ```
+  - Target front-matter:
+    ```yaml
+    ---
+    inclusion: fileMatch
+    fileMatchPattern: 'workstream/**/{user-stories,*-refinement,*-prd,*-plan}*.md'
+    ---
+    ```
+- File: `.kiro/steering/implement.md`
+  - Current front-matter:
+    ```yaml
+    ---
+    inclusion: always
+    ---
+    ```
+  - Target front-matter:
+    ```yaml
+    ---
+    inclusion: fileMatch
+    fileMatchPattern: 'workstream/**/tasks-*.md'
+    ---
+    ```
+
+**Acceptance criteria:**
+- AC-R1.1: Opening/referencing a `workstream/**/tasks-*.md` file causes
+  `implement.md` guidance to be available; a turn with no such file does not
+  inject it.
+- AC-R1.2: Opening/referencing a planning artifact (user-stories / refinement /
+  prd / plan doc) causes `plan.md` guidance to be available.
+- AC-R1.3: The body content of both files is unchanged (only front-matter is
+  edited).
+- AC-R1.4: A plain chat turn with no workstream file in context injects neither
+  playbook.
+
+> **Note:** If the executing environment's `fileMatch` implementation does not
+> support brace expansion `{a,b}`, split `plan.md` matching by using
+> `inclusion: manual` and documenting the manual `#`-context trigger instead, or
+> use the simplest reliable glob available. Verify against the host tool's
+> steering docs before finalizing the pattern.
+
+---
+
+### R2 — Fix or retire the mis-scoped Next.js steering (high impact)
+
+**Problem:** P2. **Est. savings:** ~3,100 tokens per React Native `.tsx` edit.
+
+- File: `.kiro/steering/nextjs-pages-components.md`
+  - Current front-matter:
+    ```yaml
+    ---
+    inclusion: fileMatch
+    fileMatchPattern: '**/*.tsx'
+    ---
+    ```
+  - Decision gate (confirm with user before choosing):
+    - **Option A (narrow):** If a Next.js surface exists or is planned, set the
+      pattern to its real path, e.g.:
+      ```yaml
+      fileMatchPattern: 'apps/management-hub/**/*.tsx'
+      ```
+    - **Option B (retire):** If `apps/management-hub` will not exist, delete this
+      steering file. React Native guidance for `apps/app` already lives in
+      `AGENTS.md` ("Design Specification Practice — apps/app").
+
+**Acceptance criteria:**
+- AC-R2.1: Editing a `.tsx` file under `apps/app` (React Native) does NOT inject
+  the Next.js pages/components rule.
+- AC-R2.2: If Option A is chosen, editing a `.tsx` file under the real Next.js
+  path DOES inject the rule.
+- AC-R2.3: If Option B is chosen, no active React Native `.tsx` guidance is lost
+  (confirm the `AGENTS.md` "apps/app" section covers the needed rules).
+
+---
+
+### R3 — Reduce `AGENTS.md` always-on footprint (medium impact)
+
+**Problem:** P3.
+
+`AGENTS.md` is injected on every turn. Split it so only truly global rules stay
+always-on and agent-specific / historical content loads on demand.
+
+- Keep always-on (global) in `AGENTS.md`:
+  - Branch & PR discipline (mandatory)
+  - GitHub Issue synchronization
+  - Testing & type-safety gates (`pnpm test`, `pnpm typecheck`, `pnpm lint`,
+    `pnpm format`)
+  - The short workflow checklist
+- Move out of always-on:
+  - Per-agent sections ("Agent: planner", "Agent: developer", …) → each agent's
+    own definition file already carries its constraints; deduplicate into those
+    files.
+  - "Known Procedural Failures & Safeguards" post-mortem (~400 words) → move to a
+    `fileMatch` steering doc or a `docs/` reference; it is documentation, not
+    per-turn instruction.
+  - "Design Specification Practice — apps/app" → convert to a `fileMatch`
+    steering keyed to `apps/app/**/*.tsx` (this is the correct home for the RN
+    guidance referenced in R2 Option B).
+
+**Acceptance criteria:**
+- AC-R3.1: `AGENTS.md` always-on content is reduced to the global constraints and
+  checklist (target: < ~800 words).
+- AC-R3.2: No per-agent rule is lost — each is present in the corresponding agent
+  definition file.
+- AC-R3.3: The `apps/app` design-spec guidance is injected when an
+  `apps/app/**/*.tsx` file is in context.
+- AC-R3.4: The Registry Parity Snapshot table is preserved (in `AGENTS.md` or a
+  linked doc).
+
+---
+
+### R4 — Collapse duplicated definition trees to one source of truth (medium impact)
+
+**Problem:** P4. Reduces drift and on-demand read cost.
+
+`.kiro/steering/plan.md` == `.github/instructions/plan.instructions.md` and
+`.kiro/steering/implement.md` == `.github/instructions/implement.instructions.md`
+(identical apart from front-matter). Agent files across `.kiro/agents`,
+`.github/agents`, `.claude/agents` differ only by front-matter and path
+references.
+
+Choose one canonical mechanism and apply consistently:
+- **Preferred:** Use Kiro's file-reference include (`#[[file:<relative_path>]]`)
+  so shared body content exists once and is referenced from the thin
+  tool-specific wrapper files.
+- **Alternative:** Designate `.github/` as canonical and generate the `.kiro/`
+  and `.claude/` copies via a small sync script run in CI or a pre-commit hook.
+
+**Acceptance criteria:**
+- AC-R4.1: The plan and implement rule *body* text exists in exactly one place;
+  other locations reference it.
+- AC-R4.2: A documented mechanism (include or sync script) prevents future
+  divergence.
+- AC-R4.3: Path references inside each tree still resolve correctly for that tool
+  (e.g. `.kiro` agents reference `.kiro/...`, `.github` agents reference
+  `.github/...`).
+- AC-R4.4: No agent or activity loses content during consolidation (diff-verify
+  before/after).
+
+---
+
+### R5 — Split the `memo-cli-usage` skill (medium impact)
+
+**Problem:** P5. ~5,800 tokens per invocation.
+
+Split `memo-cli-usage/SKILL.md` (present in all three skill trees) into:
+- A concise "read/write a memo" quick reference (loaded by default) —
+  target < ~1,200 words.
+- A full CLI spec loaded only when configuring/administering memo.
+
+**Acceptance criteria:**
+- AC-R5.1: The common read/write path is documented in the small file.
+- AC-R5.2: The full spec remains available and is referenced from the small file.
+- AC-R5.3: Applied consistently across whichever skill trees remain after R4.
+
+---
+
+### R6 — Scope `git-guard-notice.md` to git contexts (low impact)
+
+**Problem:** P6. ~300 tokens/turn.
+
+- File: `.kiro/steering/git-guard-notice.md`
+  - Option A: change `inclusion: always` → a git-scoped `fileMatch` (e.g. match
+    `.kiro/hooks/git-guard.json` / `.husky/**`), OR
+  - Option B: fold its single actionable line ("treat human PR review as the
+    enforcement backstop for the main-merge and commit-convention rules") into
+    the git section of `AGENTS.md` and remove the standalone always-on file.
+
+**Acceptance criteria:**
+- AC-R6.1: The git-guard enforcement-gap warning is preserved somewhere
+  reachable.
+- AC-R6.2: It no longer loads on every non-git turn.
+
+---
+
+## 5. Estimated impact
+
+- R1 + R2 together drop the per-turn always-on baseline from ~5,500 tokens to
+  roughly ~2,400 (the global slice of `AGENTS.md`) and remove the ~3,100-token
+  Next.js injection from React Native work.
+- On a ~40-turn implement session that is on the order of **200K+ tokens saved
+  per session**, with no loss of guidance.
+- R3–R6 add incremental savings and materially reduce drift/maintenance cost.
+
+### 5.1 Measured Results (Post-Implementation)
+
+| Metric | Before | After | Reduction |
+| --- | --- | --- | --- |
+| Always-on words (AGENTS.md + git-guard-notice.md) | ~4,078 | 1,119 | **73%** |
+| Always-on tokens (~words × 1.35) | ~5,500 | ~1,511 | **73%** |
+| memo-cli SKILL.md words (per invocation) | 4,293 | 553 | **87%** |
+| AGENTS.md template words | ~1,792 | 1,031 | **42%** |
+| git-guard-notice.md words | 225 | 56 | **75%** |
+| Next.js steering scope | `**/*.tsx` | `**/app/**/*.tsx` | Scoped to App Router only |
+| plan.md injection | Every turn | Only workstream files | Scoped |
+| implement.md injection | Every turn | Only tasks-*.md files | Scoped |
+
+---
+
+## 6. Verification plan
+
+For each change:
+1. **Front-matter/content edits (R1, R2, R6):** confirm the file body is
+   byte-unchanged except the intended lines (`diff` against the pre-edit copy).
+2. **Injection behavior:** in the host environment, open a file that should
+   trigger the rule and confirm the guidance is present; open an unrelated file
+   / plain chat and confirm it is absent.
+3. **No lost guidance (R3, R4, R5):** diff the aggregate rule text before and
+   after; every removed line from an always-on file MUST appear in its new home.
+4. **Path integrity (R4):** grep each tree for cross-references and confirm they
+   resolve within the correct tool tree.
+
+There is no application build to run for these changes. If the repo has a
+docs/lint check for steering front-matter, run it. Otherwise verification is the
+diff + injection-behavior checks above.
+
+---
+
+## 7. Execution notes for a fresh environment
+
+- These are configuration/documentation changes only. They fall under the
+  `AGENTS.md` exception allowing `.github/`-style config updates, but since they
+  also touch `.kiro/` steering and `AGENTS.md` itself, the executor SHOULD open a
+  feature branch and a PR rather than committing to `main` directly, per the
+  repo's branch/PR discipline.
+- Suggested branch: `chore/token-optimization-devtasks-steering`.
+- Suggested PR title (Conventional Commits):
+  `chore: reduce dev-tasks per-turn token usage via scoped steering`.
+- R2 and R6 have a decision gate (retire vs. narrow) — confirm with the user
+  before deleting any file.
+- Apply R1 first (safest, largest win), verify, then proceed.
+
+---
+
+## 8. Task checklist (for the implement activity)
+
+- [ ] R1.1 Edit `.kiro/steering/plan.md` front-matter to `fileMatch` (planning artifacts)
+- [ ] R1.2 Edit `.kiro/steering/implement.md` front-matter to `fileMatch` (`tasks-*.md`)
+- [ ] R1.3 Verify injection behavior for both (AC-R1.1..R1.4)
+- [ ] R2.1 Decide Option A (narrow) vs B (retire) with user
+- [ ] R2.2 Apply chosen change to `nextjs-pages-components.md`
+- [ ] R2.3 Verify RN `.tsx` no longer triggers the rule (AC-R2.1..R2.3)
+- [ ] R3.1 Split `AGENTS.md` into global always-on + on-demand sections
+- [ ] R3.2 Move per-agent rules into agent definition files (dedupe)
+- [ ] R3.3 Convert `apps/app` design-spec section to `fileMatch` steering
+- [ ] R3.4 Verify no per-agent rule lost (AC-R3.1..R3.4)
+- [ ] R4.1 Choose canonical mechanism (include vs sync script)
+- [ ] R4.2 Deduplicate plan/implement bodies and agent defs
+- [ ] R4.3 Verify path references + no content loss (AC-R4.1..R4.4)
+- [ ] R5.1 Split `memo-cli-usage` into quick-ref + full spec
+- [ ] R5.2 Verify across remaining skill trees (AC-R5.1..R5.3)
+- [ ] R6.1 Scope or fold `git-guard-notice.md` (AC-R6.1..R6.2)
+- [ ] Final: diff-verify all always-on reductions; open PR

--- a/workstream/tasks-token-optimization-devtasks-plan.md
+++ b/workstream/tasks-token-optimization-devtasks-plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan - Token-Usage Optimization for dev-tasks
+
+> **GitHub Issue:** [#28](https://github.com/llipe/dev-tasks/issues/28) - chore: reduce per-turn token usage via scoped steering and slimmed AGENTS.md
+
+## Relevant Files
+
+- `.kiro/steering/plan.md` - Activity playbook for plan phase (front-matter changed to fileMatch)
+- `.kiro/steering/implement.md` - Activity playbook for implement phase (front-matter changed to fileMatch)
+- `.kiro/steering/git-guard-notice.md` - Git guard enforcement gap notice (trimmed to 56 words)
+- `.kiro/steering/nextjs-pages-components.md` - Next.js/React component rules (narrowed to `**/app/**/*.tsx`)
+- `.github/instructions/plan.instructions.md` - Copilot plan instruction (scope narrowed to `workstream/**`)
+- `.github/instructions/implement.instructions.md` - Copilot implement instruction (scope narrowed)
+- `.github/instructions/domain/nextjs-pages-components.instructions.md` - Copilot Next.js instruction (tightened)
+- `.kiro/agents/developer.md` - Developer agent (added Steering Context Check)
+- `.kiro/agents/product-engineer.md` - Product-engineer agent (added Steering Context Check)
+- `.github/agents/developer.agent.md` - GitHub developer agent (added Steering Context Check)
+- `.github/agents/product-engineer.agent.md` - GitHub product-engineer agent (added Steering Context Check)
+- `.claude/agents/developer.md` - Claude developer agent (added Steering Context Check)
+- `.claude/commands/product-engineer.md` - Claude product-engineer (added Steering Context Check)
+- `.kiro/skills/memo-cli-usage/SKILL.md` - Memo CLI quick-ref (553 words)
+- `.kiro/skills/memo-cli-usage/REFERENCE.md` - Memo CLI full documentation
+- `.github/skills/memo-cli-usage/SKILL.md` - Memo CLI quick-ref for Copilot
+- `.github/skills/memo-cli-usage/REFERENCE.md` - Memo CLI full doc for Copilot
+- `.claude/skills/memo-cli-usage/SKILL.md` - Memo CLI quick-ref for Claude Code
+- `.claude/skills/memo-cli-usage/REFERENCE.md` - Memo CLI full doc for Claude Code
+- `.kiro/skills/activity-init/SKILL.md` - Added AGENTS.md sizing section
+- `.github/skills/activity-init/SKILL.md` - Added AGENTS.md sizing section
+- `.claude/skills/activity-init/SKILL.md` - Added AGENTS.md sizing section
+- `AGENTS.md` - Root project description (slimmed to 1,063 words)
+- `AGENTS.md.template` - Template for consumers (slimmed to 1,031 words)
+- `docs/agents-md-guidelines.md` - New: guidelines for healthy AGENTS.md sizing
+- `docs/workflow-chains.md` - New: relocated Workflow Chains content
+- `.gitignore` - Added exceptions for new docs files
+- `workstream/specification-token-optimization-devtasks.md` - Updated with measured results
+
+## Tasks
+
+- [x] 1.0 Convert plan/implement steering from `always` to `fileMatch` (R1)
+  - [x] 1.1 Edit `.kiro/steering/plan.md` front-matter: change `inclusion: always` to `inclusion: fileMatch` with `fileMatchPattern: "workstream/**"` 
+  - [x] 1.2 Edit `.kiro/steering/implement.md` front-matter: change `inclusion: always` to `inclusion: fileMatch` with `fileMatchPattern: "workstream/**/tasks-*.md"`
+  - [x] 1.3 Edit `.github/instructions/plan.instructions.md` front-matter: change `applyTo: "**"` to `applyTo: "workstream/**"`
+  - [x] 1.4 Edit `.github/instructions/implement.instructions.md` front-matter: change `applyTo: "**"` to `applyTo: "workstream/**/tasks-*.md"`
+  - [x] 1.5 Add lightweight context-check instruction to relevant Kiro agents: developer.md should note "If no `workstream/tasks-*.md` file is open or referenced, load the implement steering by opening the relevant task file first"; product-engineer.md should note "If no workstream planning artifact is open, reference the relevant workstream file to ensure plan guidance loads"
+  - [x] 1.6 Add equivalent lightweight context-check note in `.github/agents/developer.agent.md` and `.github/agents/product-engineer.agent.md`
+  - [x] 1.7 Add equivalent lightweight context-check note in `.claude/agents/developer.md` and `.claude/commands/product-engineer.md`
+  - [x] 1.8 Update `AGENTS.md` Instructions table to reflect new scopes (change `**` to new patterns)
+  - [x] 1.9 Update `AGENTS.md.template` Instructions table to match
+  - [x] 1.10 Verify: confirm body content of plan.md and implement.md is unchanged (diff only front-matter)
+  - [x] 1.11 Verify Acceptance Criteria: plain chat turn without workstream files should not inject either playbook
+  - [x] 1.12 Verify Acceptance Criteria: opening a tasks-*.md file should trigger implement guidance
+  - [x] 1.13 Verify Acceptance Criteria: opening a workstream planning artifact triggers plan guidance
+
+- [x] 2.0 Tighten Next.js/React steering fileMatchPattern (R2)
+  - [x] 2.1 Rename `.kiro/steering/nextjs-pages-components.md` to indicate it's a Next.js App Router specific rule; update `fileMatchPattern` from `"**/*.tsx"` to `"**/app/**/*.tsx"` (Next.js App Router convention — pages, layouts, components within app dir)
+  - [x] 2.2 Update `.github/instructions/domain/nextjs-pages-components.instructions.md` `applyTo` from `"**/*.tsx"` to `"**/app/**/*.tsx"`
+  - [x] 2.3 Add a comment block at the top of both files (below front-matter): `<!-- Consumers: adjust fileMatchPattern/applyTo to match your Next.js app path. For React Native projects, replace with a react-native steering file (see issue #13). -->`
+  - [x] 2.4 Update `AGENTS.md` and `AGENTS.md.template` Instructions table scope column to reflect new pattern
+  - [x] 2.5 Verify Acceptance Criteria: editing a `.tsx` file outside `app/` directory does NOT inject the Next.js rule
+  - [x] 2.6 Verify Acceptance Criteria: editing a `.tsx` file inside an `app/` directory DOES inject the rule
+
+- [x] 3.0 Slim AGENTS.md and create consumer sizing guidelines (R3)
+  - [x] 3.1 Review current `AGENTS.md` and `AGENTS.md.template` — identify content that is reference/documentation vs. operational guidance needed every turn
+  - [x] 3.2 Slim `AGENTS.md.template`: remove Workflow Chains section (move to a `docs/workflow-chains.md` reference doc); remove Prompts table (agents already carry their invocation modes); keep: Core Idea, Design Standard Contract, Taxonomy, Agents table, Skills tables, Instructions table, General Agent Guidelines
+  - [x] 3.3 Slim `AGENTS.md` to match the template restructure
+  - [x] 3.4 Create `docs/agents-md-guidelines.md` with: purpose of AGENTS.md, recommended max size (~1000 words / ~1,350 tokens), what belongs (operational rules enforced every turn) vs. what doesn't (reference docs, workflow diagrams, post-mortems), instructions for consumers to run `product-engineer init` to generate a right-sized AGENTS.md
+  - [x] 3.5 Add a note in `AGENTS.md.template` header pointing to the guidelines doc: "See `docs/agents-md-guidelines.md` for sizing guidance"
+  - [x] 3.6 Ensure the `activity-init` skill references the guidelines and produces a right-sized AGENTS.md during project initialization
+  - [x] 3.7 Verify Acceptance Criteria: AGENTS.md template is under ~1,000 words (measured: 1,031)
+  - [x] 3.8 Verify Acceptance Criteria: no operational guidance is lost — all removed content exists in referenced docs or agent files
+  - [x] 3.9 Verify Acceptance Criteria: Workflow Chains content is preserved in docs/
+
+- [x] 4.0 Ensure consistency across all three platform trees (R4 — no deduplication, consistency check)
+  - [x] 4.1 Verify `.kiro/steering/plan.md` body matches `.github/instructions/plan.instructions.md` body matches `.claude/skills/plan/SKILL.md` body (content only, front-matter differs by platform)
+  - [x] 4.2 Verify `.kiro/steering/implement.md` body matches `.github/instructions/implement.instructions.md` body matches `.claude/skills/implement/SKILL.md` body
+  - [x] 4.3 Verify `nextjs-pages-components` content is consistent across `.kiro/steering/` and `.github/instructions/domain/`
+  - [x] 4.4 If any drift is found, reconcile to the newest/most complete version across all trees
+  - [x] 4.5 Verify Acceptance Criteria: all three trees carry the same guidance text (diffing body content ignoring front-matter)
+
+- [x] 5.0 Split memo-cli-usage skill into quick-ref + full spec (R5)
+  - [x] 5.1 Create `.kiro/skills/memo-cli-usage/SKILL.md` as the quick-reference (target: <1,200 words) covering: setup validation check, everyday read commands (memo list, memo search, memo tags list), everyday write commands (memo add), cross-session patterns, and a pointer to `REFERENCE.md` for full CLI spec
+  - [x] 5.2 Create `.kiro/skills/memo-cli-usage/REFERENCE.md` containing the full CLI documentation (all commands, flags, configuration, admin operations, schema details)
+  - [x] 5.3 Apply same split to `.github/skills/memo-cli-usage/` (SKILL.md quick-ref + REFERENCE.md)
+  - [x] 5.4 Apply same split to `.claude/skills/memo-cli-usage/` (SKILL.md quick-ref + REFERENCE.md)
+  - [x] 5.5 Verify Acceptance Criteria: SKILL.md in all three trees is under 1,200 words (measured: 553)
+  - [x] 5.6 Verify Acceptance Criteria: REFERENCE.md contains all original content not in SKILL.md
+  - [x] 5.7 Verify Acceptance Criteria: SKILL.md includes a clear instruction for agents to read REFERENCE.md when performing setup/config/admin operations
+
+- [x] 6.0 Trim git-guard-notice.md to essential content (R6)
+  - [x] 6.1 Edit `.kiro/steering/git-guard-notice.md`: keep only front-matter + the two invariants + the single actionable backstop line; remove the verbose explanation paragraphs about the upstream defect, hook behavior, and verification comments
+  - [x] 6.2 Verify Acceptance Criteria: the file still communicates the two invariants and the human PR review backstop
+  - [x] 6.3 Verify Acceptance Criteria: word count is reduced from ~225 to ~80-100 words (measured: 56 words)
+
+- [x] 7.0 Final verification and documentation
+  - [x] 7.1 Run word count on all always-on files to confirm total reduction (measured: 1,119 words / ~1,511 tokens, target was <2,500)
+  - [x] 7.2 Verify no guidance was deleted without being relocated
+  - [x] 7.3 Update the specification document with final measured results
+  - [x] 7.4 Open PR with conventional commit: `chore: reduce per-turn token usage via scoped steering and slimmed AGENTS.md`


### PR DESCRIPTION
Reduce recurring per-turn token cost. Always-on: ~5,500 -> ~1,511 tokens (73% reduction). memo-cli SKILL.md: 4,293 -> 553 words (87%). AGENTS.md: ~1,792 -> 1,063 words. git-guard: 225 -> 56 words. No guidance removed, only relocated or scoped. Closes #28