### PR TITLE
feat: implement bootstrap commands — install, status, pin, doctor

### DIFF
--- a/adapters/cli/parse-args.ts
+++ b/adapters/cli/parse-args.ts
@@ -12,6 +12,7 @@ export interface ParsedArgs {
     verbose: boolean;
     version: boolean;
     help: boolean;
+    pin: string | undefined;
   };
 }
 
@@ -22,6 +23,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     verbose: false,
     version: false,
     help: false,
+    pin: undefined as string | undefined,
   };
 
   const positional: string[] = [];
@@ -33,6 +35,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       flags.json = true;
     } else if (arg === "--meta-repo") {
       flags.metaRepo = argv[++i];
+    } else if (arg === "--pin") {
+      flags.pin = argv[++i];
     } else if (arg === "-v" || arg === "--verbose") {
       flags.verbose = true;
     } else if (arg === "--version") {

--- a/bin/dev-tasks.ts
+++ b/bin/dev-tasks.ts
@@ -8,6 +8,10 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseArgs } from "#adapters/cli/parse-args.js";
 import { ExitCode } from "#core/exit-codes.js";
+import { installSkills } from "#core/distribution/install.js";
+import { writePin } from "#core/distribution/pin.js";
+import { getStatus } from "#core/distribution/status.js";
+import { runDoctor } from "#core/distribution/doctor.js";
 
 const COMMANDS = ["install", "update", "status", "pin", "doctor"] as const;
 
@@ -27,6 +31,21 @@ function getVersion(): string {
   return "unknown";
 }
 
+function getPackageRoot(): string {
+  let dir = import.meta.dirname;
+  for (let i = 0; i < 5; i++) {
+    const candidate = resolve(dir, "package.json");
+    try {
+      readFileSync(candidate, "utf-8");
+      return dir;
+    } catch {
+      // not found, keep going up
+    }
+    dir = resolve(dir, "..");
+  }
+  return process.cwd();
+}
+
 function printUsage(): void {
   const usage = `Usage: dev-tasks <command> [options]
 
@@ -40,6 +59,7 @@ Commands:
 Options:
   --version      Print version
   --json         Output as JSON
+  --pin <ver>    Pin to a specific version (used with install)
   --meta-repo    Path to meta repository
   -v, --verbose  Verbose output
   -h, --help     Show this help message
@@ -47,29 +67,132 @@ Options:
   process.stderr.write(usage);
 }
 
-const args = parseArgs(process.argv.slice(2));
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
 
-if (args.flags.version) {
-  process.stdout.write(getVersion() + "\n");
-  process.exit(ExitCode.Success);
+  if (args.flags.version) {
+    process.stdout.write(getVersion() + "\n");
+    process.exit(ExitCode.Success);
+  }
+
+  if (args.flags.help) {
+    printUsage();
+    process.exit(ExitCode.Success);
+  }
+
+  if (!args.command) {
+    printUsage();
+    process.exit(ExitCode.InvalidUsage);
+  }
+
+  if (!COMMANDS.includes(args.command as (typeof COMMANDS)[number])) {
+    process.stderr.write(`Unknown command: ${args.command}\n\n`);
+    printUsage();
+    process.exit(ExitCode.InvalidUsage);
+  }
+
+  const targetDir = process.cwd();
+  const packageRoot = getPackageRoot();
+  const currentVersion = getVersion();
+
+  switch (args.command) {
+    case "install": {
+      const pinVersion = args.flags.pin ?? currentVersion;
+      const result = await installSkills({
+        sourceDir: packageRoot,
+        targetDir,
+        version: currentVersion,
+        pin: pinVersion,
+      });
+
+      if (args.flags.json) {
+        process.stdout.write(
+          JSON.stringify(
+            {
+              command: "install",
+              version: currentVersion,
+              pinned: pinVersion,
+              installed: result.installed.length,
+              skills: result.installed,
+              manifestPath: result.manifestPath,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+      } else {
+        process.stdout.write(
+          `Installed ${result.installed.length} skill(s) (v${currentVersion})\n`,
+        );
+        for (const skill of result.installed) {
+          process.stdout.write(`  ✓ ${skill.name} → ${skill.path}\n`);
+        }
+        process.stdout.write(`Manifest written to ${result.manifestPath}\n`);
+      }
+      process.exit(ExitCode.Success);
+      break;
+    }
+
+    case "pin": {
+      const version = args.positional[0];
+      if (!version) {
+        process.stderr.write("Usage: dev-tasks pin <version>\n");
+        process.exit(ExitCode.InvalidUsage);
+      }
+      await writePin(targetDir, version);
+      if (args.flags.json) {
+        process.stdout.write(JSON.stringify({ command: "pin", version }, null, 2) + "\n");
+      } else {
+        process.stdout.write(`Pinned to version ${version}\n`);
+      }
+      process.exit(ExitCode.Success);
+      break;
+    }
+
+    case "status": {
+      const result = await getStatus(targetDir, currentVersion);
+      if (args.flags.json) {
+        process.stdout.write(JSON.stringify({ command: "status", ...result }, null, 2) + "\n");
+      } else {
+        process.stdout.write(`Installed: ${result.installed ?? "not installed"}\n`);
+        process.stdout.write(`Pinned:    ${result.pinned ?? "none"}\n`);
+        process.stdout.write(`Latest:    ${result.latest}\n`);
+        process.stdout.write(`Status:    ${result.upToDate ? "up to date" : "update available"}\n`);
+      }
+      process.exit(ExitCode.Success);
+      break;
+    }
+
+    case "doctor": {
+      const checks = await runDoctor({ repoRoot: targetDir });
+      if (args.flags.json) {
+        const allPass = checks.every((c) => c.pass);
+        process.stdout.write(
+          JSON.stringify({ command: "doctor", ok: allPass, checks }, null, 2) + "\n",
+        );
+      } else {
+        for (const check of checks) {
+          const icon = check.pass ? "✓" : "✗";
+          process.stdout.write(`  ${icon} ${check.name}: ${check.message}\n`);
+        }
+        const allPass = checks.every((c) => c.pass);
+        process.stdout.write(allPass ? "\nAll checks passed.\n" : "\nSome checks failed.\n");
+      }
+      const allPass = checks.every((c) => c.pass);
+      process.exit(allPass ? ExitCode.Success : ExitCode.DependencyError);
+      break;
+    }
+
+    case "update": {
+      // Stub — will be implemented in S-003
+      process.stderr.write("Command 'update' is not yet implemented.\n");
+      process.exit(ExitCode.GeneralError);
+      break;
+    }
+  }
 }
 
-if (args.flags.help) {
-  printUsage();
-  process.exit(ExitCode.Success);
-}
-
-if (!args.command) {
-  printUsage();
-  process.exit(ExitCode.InvalidUsage);
-}
-
-if (!COMMANDS.includes(args.command as (typeof COMMANDS)[number])) {
-  process.stderr.write(`Unknown command: ${args.command}\n\n`);
-  printUsage();
-  process.exit(ExitCode.InvalidUsage);
-}
-
-// Command routing — stubs for now
-process.stderr.write(`Command '${args.command}' is not yet implemented.\n`);
-process.exit(ExitCode.GeneralError);
+main().catch((err: unknown) => {
+  process.stderr.write(`Fatal error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(ExitCode.GeneralError);
+});

--- a/core/distribution/doctor.ts
+++ b/core/distribution/doctor.ts
@@ -1,0 +1,184 @@
+/**
+ * Doctor checks — validate environment prerequisites.
+ * Checks: Node >= 20, git >= 2.37, cache dir writable, version skew.
+ */
+
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { readManifest } from "./manifest.js";
+import { readPin } from "./pin.js";
+
+export interface DoctorCheck {
+  name: string;
+  pass: boolean;
+  message: string;
+}
+
+export interface DoctorOptions {
+  repoRoot: string;
+  cacheDir?: string;
+}
+
+const MIN_NODE_MAJOR = 20;
+const MIN_GIT_MAJOR = 2;
+const MIN_GIT_MINOR = 37;
+
+/**
+ * Parse a semver-like version string into major.minor.patch.
+ */
+function parseSemver(version: string): { major: number; minor: number; patch: number } | null {
+  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+  };
+}
+
+/**
+ * Check Node.js version >= 20.
+ */
+export function checkNodeVersion(versionStr?: string): DoctorCheck {
+  const version = versionStr ?? process.version;
+  const parsed = parseSemver(version);
+
+  if (!parsed || parsed.major < MIN_NODE_MAJOR) {
+    return {
+      name: "node-version",
+      pass: false,
+      message: `Node.js >= ${MIN_NODE_MAJOR} required. Found: ${version}`,
+    };
+  }
+
+  return {
+    name: "node-version",
+    pass: true,
+    message: `Node.js ${version} (>= ${MIN_NODE_MAJOR} required)`,
+  };
+}
+
+/**
+ * Check git version >= 2.37.
+ */
+export function checkGitVersion(versionStr?: string): DoctorCheck {
+  let version: string;
+  if (versionStr) {
+    version = versionStr;
+  } else {
+    try {
+      version = execSync("git --version", { encoding: "utf-8" }).trim();
+    } catch {
+      return {
+        name: "git-version",
+        pass: false,
+        message: "git is not installed or not accessible",
+      };
+    }
+  }
+
+  const parsed = parseSemver(version);
+  if (
+    !parsed ||
+    parsed.major < MIN_GIT_MAJOR ||
+    (parsed.major === MIN_GIT_MAJOR && parsed.minor < MIN_GIT_MINOR)
+  ) {
+    return {
+      name: "git-version",
+      pass: false,
+      message: `git >= ${MIN_GIT_MAJOR}.${MIN_GIT_MINOR} required. Found: ${version}`,
+    };
+  }
+
+  return {
+    name: "git-version",
+    pass: true,
+    message: `${version} (>= ${MIN_GIT_MAJOR}.${MIN_GIT_MINOR} required)`,
+  };
+}
+
+/**
+ * Check that the cache directory exists and is writable.
+ * Creates the directory if it does not exist.
+ */
+export async function checkCacheDir(cacheDir?: string): Promise<DoctorCheck> {
+  const dir = cacheDir ?? getDefaultCacheDir();
+
+  try {
+    await mkdir(dir, { recursive: true });
+    // Write a probe file to test writability
+    const probe = join(dir, ".dev-tasks-probe");
+    await writeFile(probe, "probe", "utf-8");
+    await rm(probe);
+    return {
+      name: "cache-dir",
+      pass: true,
+      message: `Cache directory writable: ${dir}`,
+    };
+  } catch {
+    return {
+      name: "cache-dir",
+      pass: false,
+      message: `Cache directory not writable: ${dir}`,
+    };
+  }
+}
+
+/**
+ * Check for version skew: installed version vs. pinned version.
+ */
+export function checkVersionSkew(installed: string | null, pinned: string | null): DoctorCheck {
+  if (pinned === null || installed === null) {
+    return {
+      name: "version-skew",
+      pass: true,
+      message: pinned === null ? "No version pin set" : "Not installed yet",
+    };
+  }
+
+  if (installed === pinned) {
+    return {
+      name: "version-skew",
+      pass: true,
+      message: `Installed ${installed} matches pin ${pinned}`,
+    };
+  }
+
+  return {
+    name: "version-skew",
+    pass: false,
+    message: `Version skew: installed ${installed} != pinned ${pinned}`,
+  };
+}
+
+/**
+ * Get the default cache directory.
+ * Uses $XDG_CACHE_HOME/dev-tasks or ~/.cache/dev-tasks.
+ */
+function getDefaultCacheDir(): string {
+  const xdg = process.env["XDG_CACHE_HOME"];
+  if (xdg) return join(xdg, "dev-tasks");
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "/tmp";
+  return join(home, ".cache", "dev-tasks");
+}
+
+/**
+ * Run all doctor checks.
+ */
+export async function runDoctor(options: DoctorOptions): Promise<DoctorCheck[]> {
+  const { repoRoot, cacheDir } = options;
+
+  const manifest = await readManifest(repoRoot);
+  const pinned = await readPin(repoRoot);
+  const installed = manifest?.version ?? null;
+
+  const checks: DoctorCheck[] = [
+    checkNodeVersion(),
+    checkGitVersion(),
+    await checkCacheDir(cacheDir),
+    checkVersionSkew(installed, pinned),
+  ];
+
+  return checks;
+}

--- a/core/distribution/hash.ts
+++ b/core/distribution/hash.ts
@@ -1,0 +1,23 @@
+/**
+ * SHA-256 hashing utilities for file content.
+ * Deterministic and reusable across distribution and reconciliation.
+ */
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+/**
+ * Compute SHA-256 hex digest of a string.
+ */
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Compute SHA-256 hex digest of a file's content.
+ * Reads the file as UTF-8 text.
+ */
+export async function hashFile(filePath: string): Promise<string> {
+  const content = await readFile(filePath, "utf-8");
+  return hashContent(content);
+}

--- a/core/distribution/index.ts
+++ b/core/distribution/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Distribution module — install, update, status, pin, doctor.
+ */
+export { hashContent, hashFile } from "./hash.js";
+export { readManifest, writeManifest } from "./manifest.js";
+export type { Manifest, SkillEntry } from "./manifest.js";
+export { installSkills } from "./install.js";
+export type { InstallOptions, InstallResult } from "./install.js";
+export { writePin, readPin } from "./pin.js";
+export { getStatus } from "./status.js";
+export type { StatusResult } from "./status.js";
+export {
+  runDoctor,
+  checkNodeVersion,
+  checkGitVersion,
+  checkCacheDir,
+  checkVersionSkew,
+} from "./doctor.js";
+export type { DoctorCheck, DoctorOptions } from "./doctor.js";

--- a/core/distribution/install.ts
+++ b/core/distribution/install.ts
@@ -1,0 +1,106 @@
+/**
+ * Install skills from the package source into the target repo.
+ * Copies skill files, computes hashes, and writes the manifest.
+ */
+
+import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { hashContent } from "./hash.js";
+import { writeManifest, type Manifest, type SkillEntry } from "./manifest.js";
+
+export interface InstallOptions {
+  /** Path to the package source directory (contains skills/) */
+  sourceDir: string;
+  /** Path to the target repo root */
+  targetDir: string;
+  /** Current package version being installed */
+  version: string;
+  /** Version to pin (defaults to version if not provided) */
+  pin: string;
+}
+
+export interface InstallResult {
+  installed: SkillEntry[];
+  manifestPath: string;
+}
+
+/**
+ * Recursively collect all files under a directory.
+ * Returns paths relative to the given baseDir.
+ */
+async function collectFiles(dir: string, baseDir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(fullPath, baseDir)));
+    } else {
+      files.push(relative(baseDir, fullPath));
+    }
+  }
+  return files;
+}
+
+/**
+ * Install skills from the package into the target repository.
+ * Copies each skill file, computes sha256 and origin_sha256, writes manifest.
+ */
+export async function installSkills(options: InstallOptions): Promise<InstallResult> {
+  const { sourceDir, targetDir, version, pin } = options;
+  const skillsSourceDir = join(sourceDir, "skills");
+  const skillsTargetDir = join(targetDir, ".dev-tasks", "skills");
+
+  // Collect all files from skills source
+  let relFiles: string[] = [];
+  try {
+    relFiles = await collectFiles(skillsSourceDir, skillsSourceDir);
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      relFiles = [];
+    } else {
+      throw err;
+    }
+  }
+
+  const skills: SkillEntry[] = [];
+
+  for (const relPath of relFiles) {
+    const sourcePath = join(skillsSourceDir, relPath);
+    const destPath = join(skillsTargetDir, relPath);
+
+    // Read source content
+    const content = await readFile(sourcePath, "utf-8");
+    const hash = hashContent(content);
+
+    // Write to target
+    const destDir = join(destPath, "..");
+    await mkdir(destDir, { recursive: true });
+    await writeFile(destPath, content, "utf-8");
+
+    // Derive skill name from first path segment
+    const skillName = relPath.split("/")[0];
+
+    skills.push({
+      name: skillName,
+      path: relPath,
+      sha256: hash,
+      origin_sha256: hash,
+    });
+  }
+
+  const manifest: Manifest = {
+    version,
+    pinned: pin,
+    installed_at: new Date().toISOString(),
+    skills,
+    extraction: {},
+  };
+
+  await writeManifest(targetDir, manifest);
+
+  return {
+    installed: skills,
+    manifestPath: join(targetDir, ".dev-tasks", "manifest.json"),
+  };
+}

--- a/core/distribution/manifest.ts
+++ b/core/distribution/manifest.ts
@@ -1,0 +1,56 @@
+/**
+ * Manifest read/write for .dev-tasks/manifest.json.
+ * Schema per spec §5.5.
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface SkillEntry {
+  name: string;
+  path: string;
+  sha256: string;
+  origin_sha256: string;
+}
+
+export interface Manifest {
+  version: string;
+  pinned: string;
+  installed_at: string;
+  skills: SkillEntry[];
+  extraction: Record<string, unknown>;
+}
+
+const MANIFEST_DIR = ".dev-tasks";
+const MANIFEST_FILE = "manifest.json";
+
+function manifestPath(repoRoot: string): string {
+  return join(repoRoot, MANIFEST_DIR, MANIFEST_FILE);
+}
+
+/**
+ * Read .dev-tasks/manifest.json from the given repo root.
+ * Returns null if the file does not exist.
+ */
+export async function readManifest(repoRoot: string): Promise<Manifest | null> {
+  try {
+    const raw = await readFile(manifestPath(repoRoot), "utf-8");
+    return JSON.parse(raw) as Manifest;
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Write .dev-tasks/manifest.json to the given repo root.
+ * Creates the .dev-tasks directory if needed.
+ */
+export async function writeManifest(repoRoot: string, manifest: Manifest): Promise<void> {
+  const dir = join(repoRoot, MANIFEST_DIR);
+  await mkdir(dir, { recursive: true });
+  const content = JSON.stringify(manifest, null, 2) + "\n";
+  await writeFile(manifestPath(repoRoot), content, "utf-8");
+}

--- a/core/distribution/pin.ts
+++ b/core/distribution/pin.ts
@@ -1,0 +1,40 @@
+/**
+ * Pin management — read/write .dev-tasks/version file.
+ * The pin file controls which package version subsequent runs use.
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const PIN_DIR = ".dev-tasks";
+const PIN_FILE = "version";
+
+function pinPath(repoRoot: string): string {
+  return join(repoRoot, PIN_DIR, PIN_FILE);
+}
+
+/**
+ * Write the pinned version to .dev-tasks/version.
+ * Creates .dev-tasks directory if needed.
+ */
+export async function writePin(repoRoot: string, version: string): Promise<void> {
+  const dir = join(repoRoot, PIN_DIR);
+  await mkdir(dir, { recursive: true });
+  await writeFile(pinPath(repoRoot), version + "\n", "utf-8");
+}
+
+/**
+ * Read the pinned version from .dev-tasks/version.
+ * Returns null if no pin file exists.
+ */
+export async function readPin(repoRoot: string): Promise<string | null> {
+  try {
+    const content = await readFile(pinPath(repoRoot), "utf-8");
+    return content.trim();
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}

--- a/core/distribution/status.ts
+++ b/core/distribution/status.ts
@@ -1,0 +1,48 @@
+/**
+ * Status reporting — compare installed vs. pinned vs. latest versions.
+ */
+
+import { readManifest } from "./manifest.js";
+import { readPin } from "./pin.js";
+
+export interface StatusResult {
+  installed: string | null;
+  pinned: string | null;
+  latest: string;
+  upToDate: boolean;
+}
+
+/**
+ * Get the current status of the dev-tasks installation.
+ * Compares installed version (from manifest), pinned version (from .dev-tasks/version),
+ * and the latest published version.
+ *
+ * upToDate is true when:
+ * - If pinned: installed version matches the pinned version
+ * - If not pinned: installed version matches the latest version
+ */
+export async function getStatus(repoRoot: string, latestVersion: string): Promise<StatusResult> {
+  const manifest = await readManifest(repoRoot);
+  const pinned = await readPin(repoRoot);
+
+  const installed = manifest?.version ?? null;
+
+  // Determine if up-to-date:
+  // - If pinned, compare installed against pin
+  // - If not pinned, compare installed against latest
+  let upToDate: boolean;
+  if (installed === null) {
+    upToDate = false;
+  } else if (pinned !== null) {
+    upToDate = installed === pinned;
+  } else {
+    upToDate = installed === latestVersion;
+  }
+
+  return {
+    installed,
+    pinned,
+    latest: latestVersion,
+    upToDate,
+  };
+}

--- a/core/index.ts
+++ b/core/index.ts
@@ -7,6 +7,7 @@ export type { ExitCodeValue } from "./exit-codes.js";
 
 // Module stubs — will be populated as features are implemented
 export * as catalog from "./catalog/index.js";
+export * as distribution from "./distribution/index.js";
 export * as extract from "./extract/index.js";
 export * as context from "./context/index.js";
 export * as scope from "./scope/index.js";

--- a/test/integration/bootstrap-commands.test.ts
+++ b/test/integration/bootstrap-commands.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { execSync, execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import type { Manifest } from "#core/distribution/manifest.js";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+const DIST_BIN = resolve(ROOT, "dist/bin/dev-tasks.js");
+
+describe("dev-tasks bootstrap commands (integration)", () => {
+  beforeAll(() => {
+    // Ensure the project is built
+    if (!existsSync(DIST_BIN)) {
+      execSync("pnpm run build", { cwd: ROOT, encoding: "utf-8" });
+    }
+  });
+
+  function run(
+    args: string[],
+    options: { cwd?: string } = {},
+  ): { stdout: string; stderr: string; exitCode: number } {
+    const cwd = options.cwd ?? ROOT;
+    try {
+      const stdout = execFileSync("node", [DIST_BIN, ...args], {
+        cwd,
+        encoding: "utf-8",
+        env: { ...process.env, NODE_ENV: "test" },
+        timeout: 10_000,
+      });
+      return { stdout, stderr: "", exitCode: 0 };
+    } catch (err: unknown) {
+      const e = err as { stdout?: string; stderr?: string; status?: number };
+      return {
+        stdout: e.stdout ?? "",
+        stderr: e.stderr ?? "",
+        exitCode: e.status ?? 1,
+      };
+    }
+  }
+
+  describe("install", () => {
+    let tmpDir: string;
+    let skillsDir: string;
+    let skillTestDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-int-install-"));
+      // Create a test skills dir in the package source
+      skillsDir = join(ROOT, "skills");
+      skillTestDir = join(skillsDir, "test-integration-skill");
+      mkdirSync(skillTestDir, { recursive: true });
+      writeFileSync(
+        join(skillTestDir, "SKILL.md"),
+        "# Integration Test Skill\nContent here.",
+        "utf-8",
+      );
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(skillTestDir, { recursive: true, force: true });
+      // Remove skills dir only if empty
+      try {
+        rmSync(skillsDir, { recursive: false });
+      } catch {
+        // Not empty, fine
+      }
+    });
+
+    it("installs skills and writes manifest with sha256/origin_sha256", () => {
+      const result = run(["install"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+
+      const manifestPath = join(tmpDir, ".dev-tasks", "manifest.json");
+      expect(existsSync(manifestPath)).toBe(true);
+
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as Manifest;
+      expect(manifest.version).toBe("0.1.0");
+      expect(manifest.skills.length).toBeGreaterThanOrEqual(1);
+
+      for (const skill of manifest.skills) {
+        expect(skill.sha256).toMatch(/^[a-f0-9]{64}$/);
+        expect(skill.origin_sha256).toMatch(/^[a-f0-9]{64}$/);
+      }
+    });
+
+    it("supports --json output for install", () => {
+      const result = run(["install", "--json"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(output.command).toBe("install");
+      expect(output.version).toBe("0.1.0");
+      expect(typeof output.installed).toBe("number");
+      expect(Array.isArray(output.skills)).toBe(true);
+    });
+
+    it("supports --pin flag to set a specific pinned version", () => {
+      const result = run(["install", "--pin", "0.0.5", "--json"], {
+        cwd: tmpDir,
+      });
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(output.pinned).toBe("0.0.5");
+
+      const manifest = JSON.parse(
+        readFileSync(join(tmpDir, ".dev-tasks", "manifest.json"), "utf-8"),
+      ) as Manifest;
+      expect(manifest.pinned).toBe("0.0.5");
+    });
+  });
+
+  describe("pin", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-int-pin-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("writes .dev-tasks/version file", () => {
+      const result = run(["pin", "1.2.3"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+
+      const versionFile = join(tmpDir, ".dev-tasks", "version");
+      expect(existsSync(versionFile)).toBe(true);
+      expect(readFileSync(versionFile, "utf-8").trim()).toBe("1.2.3");
+    });
+
+    it("supports --json output for pin", () => {
+      const result = run(["pin", "2.0.0", "--json"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(output.command).toBe("pin");
+      expect(output.version).toBe("2.0.0");
+    });
+
+    it("exits 2 if no version argument provided", () => {
+      const result = run(["pin"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("pin is honored — subsequent status reports pinned version", () => {
+      // First pin
+      run(["pin", "0.5.0"], { cwd: tmpDir });
+
+      // Then check status
+      const statusResult = run(["status", "--json"], { cwd: tmpDir });
+      const output = JSON.parse(statusResult.stdout) as Record<string, unknown>;
+      expect(output.pinned).toBe("0.5.0");
+    });
+  });
+
+  describe("status", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-int-status-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("reports not installed when no manifest exists", () => {
+      const result = run(["status"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/not installed/);
+    });
+
+    it("reports installed version from manifest", () => {
+      mkdirSync(join(tmpDir, ".dev-tasks"), { recursive: true });
+      writeFileSync(
+        join(tmpDir, ".dev-tasks", "manifest.json"),
+        JSON.stringify({
+          version: "0.1.0",
+          pinned: "0.1.0",
+          installed_at: "2024-01-01T00:00:00.000Z",
+          skills: [],
+          extraction: {},
+        }),
+        "utf-8",
+      );
+
+      const result = run(["status"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/0\.1\.0/);
+    });
+
+    it("supports --json output shape with all three versions", () => {
+      mkdirSync(join(tmpDir, ".dev-tasks"), { recursive: true });
+      writeFileSync(
+        join(tmpDir, ".dev-tasks", "manifest.json"),
+        JSON.stringify({
+          version: "0.1.0",
+          pinned: "0.1.0",
+          installed_at: "2024-01-01T00:00:00.000Z",
+          skills: [],
+          extraction: {},
+        }),
+        "utf-8",
+      );
+      writeFileSync(join(tmpDir, ".dev-tasks", "version"), "0.2.0\n", "utf-8");
+
+      const result = run(["status", "--json"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(output.command).toBe("status");
+      expect(output.installed).toBe("0.1.0");
+      expect(output.pinned).toBe("0.2.0");
+      expect(output).toHaveProperty("latest");
+      expect(output).toHaveProperty("upToDate");
+    });
+  });
+
+  describe("doctor", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-int-doctor-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("runs all checks and outputs results", () => {
+      const result = run(["doctor"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/node-version/);
+      expect(result.stdout).toMatch(/git-version/);
+      expect(result.stdout).toMatch(/cache-dir/);
+      expect(result.stdout).toMatch(/version-skew/);
+    });
+
+    it("supports --json output with structured check results", () => {
+      const result = run(["doctor", "--json"], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout) as {
+        command: string;
+        ok: boolean;
+        checks: Array<{ name: string; pass: boolean; message: string }>;
+      };
+      expect(output.command).toBe("doctor");
+      expect(typeof output.ok).toBe("boolean");
+      expect(Array.isArray(output.checks)).toBe(true);
+      expect(output.checks.length).toBeGreaterThanOrEqual(4);
+
+      for (const check of output.checks) {
+        expect(check).toHaveProperty("name");
+        expect(check).toHaveProperty("pass");
+        expect(check).toHaveProperty("message");
+      }
+    });
+
+    it("detects version skew when pin differs from installed", () => {
+      mkdirSync(join(tmpDir, ".dev-tasks"), { recursive: true });
+      writeFileSync(
+        join(tmpDir, ".dev-tasks", "manifest.json"),
+        JSON.stringify({
+          version: "0.0.1",
+          pinned: "0.0.1",
+          installed_at: "2024-01-01T00:00:00.000Z",
+          skills: [],
+          extraction: {},
+        }),
+        "utf-8",
+      );
+      writeFileSync(join(tmpDir, ".dev-tasks", "version"), "0.9.9\n", "utf-8");
+
+      const result = run(["doctor", "--json"], { cwd: tmpDir });
+      const output = JSON.parse(result.stdout) as {
+        ok: boolean;
+        checks: Array<{ name: string; pass: boolean; message: string }>;
+      };
+      const skewCheck = output.checks.find((c) => c.name === "version-skew");
+      expect(skewCheck?.pass).toBe(false);
+      expect(skewCheck?.message).toMatch(/skew/i);
+    });
+  });
+});

--- a/test/unit/distribution-doctor.test.ts
+++ b/test/unit/distribution-doctor.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  checkNodeVersion,
+  checkGitVersion,
+  checkCacheDir,
+  checkVersionSkew,
+  runDoctor,
+} from "#core/distribution/doctor.js";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("core/distribution/doctor", () => {
+  describe("checkNodeVersion", () => {
+    it("passes when Node version >= 20", () => {
+      const result = checkNodeVersion("v20.0.0");
+      expect(result.pass).toBe(true);
+      expect(result.name).toBe("node-version");
+    });
+
+    it("passes for Node v22.x", () => {
+      const result = checkNodeVersion("v22.5.1");
+      expect(result.pass).toBe(true);
+    });
+
+    it("fails for Node v18.x", () => {
+      const result = checkNodeVersion("v18.19.0");
+      expect(result.pass).toBe(false);
+      expect(result.message).toMatch(/20/);
+    });
+
+    it("fails for Node v16.x", () => {
+      const result = checkNodeVersion("v16.0.0");
+      expect(result.pass).toBe(false);
+    });
+  });
+
+  describe("checkGitVersion", () => {
+    it("passes when git version >= 2.37", () => {
+      const result = checkGitVersion("git version 2.37.0");
+      expect(result.pass).toBe(true);
+      expect(result.name).toBe("git-version");
+    });
+
+    it("passes for git 2.43.0", () => {
+      const result = checkGitVersion("git version 2.43.0");
+      expect(result.pass).toBe(true);
+    });
+
+    it("fails for git 2.36.9", () => {
+      const result = checkGitVersion("git version 2.36.9");
+      expect(result.pass).toBe(false);
+      expect(result.message).toMatch(/2\.37/);
+    });
+
+    it("fails for git 1.x", () => {
+      const result = checkGitVersion("git version 1.9.5");
+      expect(result.pass).toBe(false);
+    });
+
+    it("handles Apple git version strings", () => {
+      const result = checkGitVersion("git version 2.39.5 (Apple Git-154)");
+      expect(result.pass).toBe(true);
+    });
+  });
+
+  describe("checkCacheDir", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-doctor-cache-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("passes when cache directory is writable", async () => {
+      const result = await checkCacheDir(tmpDir);
+      expect(result.pass).toBe(true);
+      expect(result.name).toBe("cache-dir");
+    });
+
+    it("creates the cache directory if it does not exist", async () => {
+      const newDir = join(tmpDir, "new-cache");
+      const result = await checkCacheDir(newDir);
+      expect(result.pass).toBe(true);
+    });
+
+    it("fails when path is not writable", async () => {
+      // Use a path that definitely can't be written
+      const result = await checkCacheDir("/root/no-access-dev-tasks-cache");
+      expect(result.pass).toBe(false);
+    });
+  });
+
+  describe("checkVersionSkew", () => {
+    it("passes when installed matches pinned", () => {
+      const result = checkVersionSkew("0.1.0", "0.1.0");
+      expect(result.pass).toBe(true);
+      expect(result.name).toBe("version-skew");
+    });
+
+    it("fails when installed differs from pinned", () => {
+      const result = checkVersionSkew("0.1.0", "0.2.0");
+      expect(result.pass).toBe(false);
+      expect(result.message).toMatch(/skew/i);
+    });
+
+    it("passes when no pin exists (null)", () => {
+      const result = checkVersionSkew("0.1.0", null);
+      expect(result.pass).toBe(true);
+    });
+
+    it("passes when not installed and no pin", () => {
+      const result = checkVersionSkew(null, null);
+      expect(result.pass).toBe(true);
+    });
+  });
+
+  describe("runDoctor", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-doctor-run-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns an array of DoctorCheck results", async () => {
+      mkdirSync(join(tmpDir, ".dev-tasks"), { recursive: true });
+      writeFileSync(
+        join(tmpDir, ".dev-tasks", "manifest.json"),
+        JSON.stringify({
+          version: "0.1.0",
+          pinned: "0.1.0",
+          installed_at: "2024-01-01T00:00:00.000Z",
+          skills: [],
+          extraction: {},
+        }),
+        "utf-8",
+      );
+
+      const results = await runDoctor({
+        repoRoot: tmpDir,
+        cacheDir: tmpDir,
+      });
+
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBeGreaterThanOrEqual(4);
+      for (const check of results) {
+        expect(check).toHaveProperty("name");
+        expect(check).toHaveProperty("pass");
+        expect(check).toHaveProperty("message");
+      }
+    });
+
+    it("includes all four check categories", async () => {
+      const results = await runDoctor({
+        repoRoot: tmpDir,
+        cacheDir: tmpDir,
+      });
+
+      const names = results.map((r) => r.name);
+      expect(names).toContain("node-version");
+      expect(names).toContain("git-version");
+      expect(names).toContain("cache-dir");
+      expect(names).toContain("version-skew");
+    });
+  });
+});

--- a/test/unit/distribution-hash.test.ts
+++ b/test/unit/distribution-hash.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { hashContent, hashFile } from "#core/distribution/hash.js";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+
+describe("core/distribution/hash", () => {
+  describe("hashContent", () => {
+    it("returns a SHA-256 hex digest of the input string", () => {
+      const content = "hello world";
+      const expected = createHash("sha256").update(content).digest("hex");
+      expect(hashContent(content)).toBe(expected);
+    });
+
+    it("returns deterministic output for same input", () => {
+      const content = "deterministic test";
+      expect(hashContent(content)).toBe(hashContent(content));
+    });
+
+    it("produces different hashes for different inputs", () => {
+      expect(hashContent("aaa")).not.toBe(hashContent("bbb"));
+    });
+
+    it("handles empty string", () => {
+      const expected = createHash("sha256").update("").digest("hex");
+      expect(hashContent("")).toBe(expected);
+    });
+
+    it("handles multi-line content", () => {
+      const content = "line1\nline2\nline3";
+      const expected = createHash("sha256").update(content).digest("hex");
+      expect(hashContent(content)).toBe(expected);
+    });
+
+    it("handles unicode content", () => {
+      const content = "日本語テスト 🎉";
+      const expected = createHash("sha256").update(content).digest("hex");
+      expect(hashContent(content)).toBe(expected);
+    });
+  });
+
+  describe("hashFile", () => {
+    let tmpDir: string;
+
+    function setup() {
+      tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-hash-test-"));
+    }
+
+    function teardown() {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    it("returns the SHA-256 hash of a file's content", async () => {
+      setup();
+      try {
+        const filePath = join(tmpDir, "test.txt");
+        const content = "file content for hashing";
+        writeFileSync(filePath, content, "utf-8");
+
+        const expected = createHash("sha256").update(content).digest("hex");
+        const result = await hashFile(filePath);
+        expect(result).toBe(expected);
+      } finally {
+        teardown();
+      }
+    });
+
+    it("throws for a non-existent file", async () => {
+      await expect(hashFile("/nonexistent/path/file.txt")).rejects.toThrow();
+    });
+
+    it("handles an empty file", async () => {
+      setup();
+      try {
+        const filePath = join(tmpDir, "empty.txt");
+        writeFileSync(filePath, "", "utf-8");
+
+        const expected = createHash("sha256").update("").digest("hex");
+        const result = await hashFile(filePath);
+        expect(result).toBe(expected);
+      } finally {
+        teardown();
+      }
+    });
+  });
+});

--- a/test/unit/distribution-install.test.ts
+++ b/test/unit/distribution-install.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { installSkills } from "#core/distribution/install.js";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import type { Manifest } from "#core/distribution/manifest.js";
+
+describe("core/distribution/install", () => {
+  let tmpDir: string;
+  let targetDir: string;
+  let sourceDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-install-test-"));
+    targetDir = join(tmpDir, "target-repo");
+    sourceDir = join(tmpDir, "package-source");
+    mkdirSync(targetDir, { recursive: true });
+    mkdirSync(join(sourceDir, "skills"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function createSkillFile(name: string, content: string): void {
+    const skillDir = join(sourceDir, "skills", name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), content, "utf-8");
+  }
+
+  function sha256(content: string): string {
+    return createHash("sha256").update(content).digest("hex");
+  }
+
+  it("copies skill files from source to target repo", async () => {
+    createSkillFile("activity-refine", "# Refine Skill\nContent here.");
+    const result = await installSkills({
+      sourceDir,
+      targetDir,
+      version: "0.1.0",
+      pin: "0.1.0",
+    });
+
+    const installedPath = join(targetDir, ".dev-tasks", "skills", "activity-refine", "SKILL.md");
+    expect(existsSync(installedPath)).toBe(true);
+    expect(readFileSync(installedPath, "utf-8")).toBe("# Refine Skill\nContent here.");
+    expect(result.installed).toHaveLength(1);
+  });
+
+  it("writes a valid manifest with sha256 and origin_sha256", async () => {
+    const content = "# Test Skill";
+    createSkillFile("test-skill", content);
+    await installSkills({
+      sourceDir,
+      targetDir,
+      version: "0.1.0",
+      pin: "0.1.0",
+    });
+
+    const manifestRaw = readFileSync(join(targetDir, ".dev-tasks", "manifest.json"), "utf-8");
+    const manifest = JSON.parse(manifestRaw) as Manifest;
+
+    expect(manifest.version).toBe("0.1.0");
+    expect(manifest.pinned).toBe("0.1.0");
+    expect(manifest.installed_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(manifest.skills).toHaveLength(1);
+    expect(manifest.skills[0].name).toBe("test-skill");
+    expect(manifest.skills[0].sha256).toBe(sha256(content));
+    expect(manifest.skills[0].origin_sha256).toBe(sha256(content));
+  });
+
+  it("handles multiple skills", async () => {
+    createSkillFile("skill-a", "Content A");
+    createSkillFile("skill-b", "Content B");
+
+    const result = await installSkills({
+      sourceDir,
+      targetDir,
+      version: "0.2.0",
+      pin: "0.2.0",
+    });
+
+    expect(result.installed).toHaveLength(2);
+    const manifestRaw = readFileSync(join(targetDir, ".dev-tasks", "manifest.json"), "utf-8");
+    const manifest = JSON.parse(manifestRaw) as Manifest;
+    expect(manifest.skills).toHaveLength(2);
+  });
+
+  it("uses provided pin version in manifest", async () => {
+    createSkillFile("skill-x", "X");
+    await installSkills({
+      sourceDir,
+      targetDir,
+      version: "0.3.0",
+      pin: "0.2.0",
+    });
+
+    const manifestRaw = readFileSync(join(targetDir, ".dev-tasks", "manifest.json"), "utf-8");
+    const manifest = JSON.parse(manifestRaw) as Manifest;
+    expect(manifest.version).toBe("0.3.0");
+    expect(manifest.pinned).toBe("0.2.0");
+  });
+
+  it("creates .dev-tasks directory structure automatically", async () => {
+    createSkillFile("my-skill", "data");
+    await installSkills({
+      sourceDir,
+      targetDir,
+      version: "0.1.0",
+      pin: "0.1.0",
+    });
+
+    expect(existsSync(join(targetDir, ".dev-tasks"))).toBe(true);
+    expect(existsSync(join(targetDir, ".dev-tasks", "manifest.json"))).toBe(true);
+    expect(existsSync(join(targetDir, ".dev-tasks", "skills"))).toBe(true);
+  });
+
+  it("handles empty skills directory (no skills to install)", async () => {
+    // sourceDir/skills/ exists but is empty
+    const result = await installSkills({
+      sourceDir,
+      targetDir,
+      version: "0.1.0",
+      pin: "0.1.0",
+    });
+
+    expect(result.installed).toHaveLength(0);
+    const manifestRaw = readFileSync(join(targetDir, ".dev-tasks", "manifest.json"), "utf-8");
+    const manifest = JSON.parse(manifestRaw) as Manifest;
+    expect(manifest.skills).toEqual([]);
+  });
+});

--- a/test/unit/distribution-manifest.test.ts
+++ b/test/unit/distribution-manifest.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readManifest, writeManifest, type Manifest } from "#core/distribution/manifest.js";
+import { mkdtempSync, rmSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("core/distribution/manifest", () => {
+  let tmpDir: string;
+  let devTasksDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-manifest-test-"));
+    devTasksDir = join(tmpDir, ".dev-tasks");
+    mkdirSync(devTasksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const sampleManifest: Manifest = {
+    version: "0.1.0",
+    pinned: "0.1.0",
+    installed_at: "2024-01-01T00:00:00.000Z",
+    skills: [
+      {
+        name: "activity-refine",
+        path: ".claude/skills/activity-refine/SKILL.md",
+        sha256: "abc123",
+        origin_sha256: "def456",
+      },
+    ],
+    extraction: {},
+  };
+
+  describe("writeManifest", () => {
+    it("writes manifest.json to .dev-tasks directory", async () => {
+      await writeManifest(tmpDir, sampleManifest);
+      const raw = readFileSync(join(devTasksDir, "manifest.json"), "utf-8");
+      const parsed = JSON.parse(raw) as Manifest;
+      expect(parsed.version).toBe("0.1.0");
+      expect(parsed.skills).toHaveLength(1);
+    });
+
+    it("creates .dev-tasks directory if missing", async () => {
+      const freshDir = mkdtempSync(join(tmpdir(), "dev-tasks-manifest-fresh-"));
+      try {
+        await writeManifest(freshDir, sampleManifest);
+        const raw = readFileSync(join(freshDir, ".dev-tasks", "manifest.json"), "utf-8");
+        expect(JSON.parse(raw)).toEqual(sampleManifest);
+      } finally {
+        rmSync(freshDir, { recursive: true, force: true });
+      }
+    });
+
+    it("formats JSON with 2-space indentation", async () => {
+      await writeManifest(tmpDir, sampleManifest);
+      const raw = readFileSync(join(devTasksDir, "manifest.json"), "utf-8");
+      expect(raw).toContain("  ");
+      expect(raw.endsWith("\n")).toBe(true);
+    });
+  });
+
+  describe("readManifest", () => {
+    it("reads an existing manifest.json", async () => {
+      await writeManifest(tmpDir, sampleManifest);
+      const result = await readManifest(tmpDir);
+      expect(result).toEqual(sampleManifest);
+    });
+
+    it("returns null if manifest.json does not exist", async () => {
+      const emptyDir = mkdtempSync(join(tmpdir(), "dev-tasks-no-manifest-"));
+      try {
+        const result = await readManifest(emptyDir);
+        expect(result).toBeNull();
+      } finally {
+        rmSync(emptyDir, { recursive: true, force: true });
+      }
+    });
+
+    it("round-trips correctly", async () => {
+      await writeManifest(tmpDir, sampleManifest);
+      const result = await readManifest(tmpDir);
+      expect(result).toEqual(sampleManifest);
+    });
+  });
+
+  describe("manifest schema validation", () => {
+    it("allows empty skills array", async () => {
+      const manifest: Manifest = {
+        version: "0.1.0",
+        pinned: "0.1.0",
+        installed_at: new Date().toISOString(),
+        skills: [],
+        extraction: {},
+      };
+      await writeManifest(tmpDir, manifest);
+      const result = await readManifest(tmpDir);
+      expect(result?.skills).toEqual([]);
+    });
+
+    it("preserves extraction data", async () => {
+      const manifest: Manifest = {
+        version: "0.1.0",
+        pinned: "0.1.0",
+        installed_at: new Date().toISOString(),
+        skills: [],
+        extraction: { schema: { lastRun: "2024-01-01" } },
+      };
+      await writeManifest(tmpDir, manifest);
+      const result = await readManifest(tmpDir);
+      expect(result?.extraction).toEqual({ schema: { lastRun: "2024-01-01" } });
+    });
+  });
+});

--- a/test/unit/distribution-pin.test.ts
+++ b/test/unit/distribution-pin.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writePin, readPin } from "#core/distribution/pin.js";
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("core/distribution/pin", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-pin-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("writePin", () => {
+    it("writes the version to .dev-tasks/version", async () => {
+      await writePin(tmpDir, "1.2.3");
+      const content = readFileSync(join(tmpDir, ".dev-tasks", "version"), "utf-8");
+      expect(content.trim()).toBe("1.2.3");
+    });
+
+    it("creates .dev-tasks directory if missing", async () => {
+      await writePin(tmpDir, "0.5.0");
+      const content = readFileSync(join(tmpDir, ".dev-tasks", "version"), "utf-8");
+      expect(content.trim()).toBe("0.5.0");
+    });
+
+    it("overwrites existing pin", async () => {
+      await writePin(tmpDir, "1.0.0");
+      await writePin(tmpDir, "2.0.0");
+      const content = readFileSync(join(tmpDir, ".dev-tasks", "version"), "utf-8");
+      expect(content.trim()).toBe("2.0.0");
+    });
+  });
+
+  describe("readPin", () => {
+    it("reads the pinned version from .dev-tasks/version", async () => {
+      mkdirSync(join(tmpDir, ".dev-tasks"), { recursive: true });
+      writeFileSync(join(tmpDir, ".dev-tasks", "version"), "1.5.0\n", "utf-8");
+      const result = await readPin(tmpDir);
+      expect(result).toBe("1.5.0");
+    });
+
+    it("returns null if no pin file exists", async () => {
+      const result = await readPin(tmpDir);
+      expect(result).toBeNull();
+    });
+
+    it("trims whitespace from the version", async () => {
+      mkdirSync(join(tmpDir, ".dev-tasks"), { recursive: true });
+      writeFileSync(join(tmpDir, ".dev-tasks", "version"), "  3.0.0  \n", "utf-8");
+      const result = await readPin(tmpDir);
+      expect(result).toBe("3.0.0");
+    });
+  });
+});

--- a/test/unit/distribution-status.test.ts
+++ b/test/unit/distribution-status.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getStatus } from "#core/distribution/status.js";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("core/distribution/status", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dev-tasks-status-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeManifest(version: string, pinned: string): void {
+    const dir = join(tmpDir, ".dev-tasks");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "manifest.json"),
+      JSON.stringify({
+        version,
+        pinned,
+        installed_at: "2024-01-01T00:00:00.000Z",
+        skills: [],
+        extraction: {},
+      }),
+      "utf-8",
+    );
+  }
+
+  function writePin(version: string): void {
+    const dir = join(tmpDir, ".dev-tasks");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "version"), version + "\n", "utf-8");
+  }
+
+  it("reports installed version from manifest", async () => {
+    writeManifest("0.1.0", "0.1.0");
+    const result = await getStatus(tmpDir, "0.2.0");
+    expect(result.installed).toBe("0.1.0");
+  });
+
+  it("reports pinned version from .dev-tasks/version file", async () => {
+    writeManifest("0.1.0", "0.1.0");
+    writePin("0.1.5");
+    const result = await getStatus(tmpDir, "0.2.0");
+    expect(result.pinned).toBe("0.1.5");
+  });
+
+  it("reports pinned as null if no pin file exists", async () => {
+    writeManifest("0.1.0", "0.1.0");
+    const result = await getStatus(tmpDir, "0.2.0");
+    expect(result.pinned).toBeNull();
+  });
+
+  it("reports latest version from argument", async () => {
+    writeManifest("0.1.0", "0.1.0");
+    const result = await getStatus(tmpDir, "0.3.0");
+    expect(result.latest).toBe("0.3.0");
+  });
+
+  it("reports all three versions", async () => {
+    writeManifest("0.1.0", "0.1.0");
+    writePin("0.2.0");
+    const result = await getStatus(tmpDir, "0.3.0");
+    expect(result.installed).toBe("0.1.0");
+    expect(result.pinned).toBe("0.2.0");
+    expect(result.latest).toBe("0.3.0");
+  });
+
+  it("reports installed as null if not installed", async () => {
+    const result = await getStatus(tmpDir, "0.1.0");
+    expect(result.installed).toBeNull();
+    expect(result.pinned).toBeNull();
+  });
+
+  it("marks upToDate correctly when installed matches latest", async () => {
+    writeManifest("0.2.0", "0.2.0");
+    const result = await getStatus(tmpDir, "0.2.0");
+    expect(result.upToDate).toBe(true);
+  });
+
+  it("marks upToDate false when installed differs from latest", async () => {
+    writeManifest("0.1.0", "0.1.0");
+    const result = await getStatus(tmpDir, "0.2.0");
+    expect(result.upToDate).toBe(false);
+  });
+
+  it("marks upToDate based on pin when pinned", async () => {
+    writeManifest("0.1.0", "0.1.0");
+    writePin("0.1.0");
+    const result = await getStatus(tmpDir, "0.2.0");
+    // When pinned, upToDate means installed matches pin
+    expect(result.upToDate).toBe(true);
+  });
+});

--- a/workstream/tasks-multi-repo-context-plan.md
+++ b/workstream/tasks-multi-repo-context-plan.md
@@ -1,0 +1,239 @@
+# Implementation Plan — Multi-Repo Context (Phase 0 + Phase 1)
+
+## Relevant Files
+
+- `package.json` - Package manifest (bin, engines, scripts, dependencies)
+- `tsconfig.json` - TypeScript configuration
+- `.eslintrc.*` / `eslint.config.*` - Lint configuration
+- `.prettierrc` / `prettier.config.*` - Format configuration
+- `vitest.config.ts` or `jest.config.ts` - Test runner configuration
+- `bin/dev-tasks.ts` - Bootstrap binary entrypoint
+- `bin/dt.ts` - Runtime binary entrypoint
+- `core/index.ts` - Core library barrel export
+- `core/exit-codes.ts` - Shared exit-code enum
+- `core/reconcile.ts` - Generic hash reconciliation engine
+- `core/distribution/manifest.ts` - Manifest read/write
+- `core/distribution/hash.ts` - SHA-256 hashing utility
+- `core/distribution/doctor.ts` - Environment prerequisite checks
+- `core/distribution/backup.ts` - Timestamped backup for --force
+- `core/distribution/migrate.ts` - Legacy shim migration
+- `core/extract/provider.ts` - ExtractionProvider interface + Capability type
+- `core/extract/detect.ts` - Stack/framework/ORM/messaging detection
+- `core/extract/providers/node-ts.ts` - Node/TS extraction provider
+- `core/extract/schema.ts` - Schema extraction orchestrator
+- `core/extract/orm/prisma.ts` - Prisma AST extractor
+- `core/extract/orm/drizzle.ts` - Drizzle AST extractor
+- `core/extract/orm/typeorm.ts` - TypeORM AST extractor
+- `core/extract/render/schema-md.ts` - schema.md renderer (tables + Mermaid)
+- `core/extract/openapi/route1.ts` - OpenAPI route 1 (copy + normalize)
+- `core/extract/openapi/route3.ts` - OpenAPI route 3 (AST + LLM descriptions)
+- `core/extract/openapi/validate.ts` - OpenAPI 3.1 schema validation
+- `core/extract/asyncapi/topics.ts` - Kafka topic inventory AST extraction
+- `core/extract/asyncapi/payloads.ts` - Kafka payload classification
+- `core/extract/asyncapi/validate.ts` - AsyncAPI schema validation
+- `core/extract/component.ts` - component.yaml derivation + provenance
+- `core/extract/report.ts` - extraction_report.json generation
+- `core/extract/prompt.ts` - Interactive prompt for non-derivable fields
+- `adapters/cli/index.ts` - CLI adapter (wraps core, formats stdout/JSON)
+- `schemas/component.schema.json` - component.yaml JSON Schema (draft for validation during extraction)
+- `test/fixtures/extract/*` - Fixture repos per stack combination
+- `dev-tasks.sh` - Replaced by migration shim
+- `.dev-tasks/manifest.json` - Per-repo install manifest (generated)
+- `CHANGELOG.md` - Release changelog
+
+## Tasks
+
+- [ ] 0.0 Project Setup (greenfield `@llipe/dev-tasks` package)
+  - [x] 0.1 Initialize the package (`pnpm init`, set `name: @llipe/dev-tasks`, `engines.node: >=20`, `type: module`)
+  - [x] 0.2 Configure TypeScript (`tsconfig.json`: strict, ESM, `outDir: dist/`, path aliases for `core/` and `adapters/`)
+  - [x] 0.3 Configure linting and formatting (ESLint + Prettier; add `lint`, `lint:fix`, `format`, `format:check` scripts)
+  - [x] 0.4 Configure test runner (Vitest recommended; add `test`, `test:unit`, `test:integration` scripts)
+  - [x] 0.5 Add `typecheck` script (`tsc --noEmit`), `audit` script (`pnpm audit`), and `validate` aggregate script
+  - [x] 0.6 Create directory layout: `bin/`, `core/{catalog,extract,context,scope,providers}`, `adapters/{cli,mcp}`, `skills/`, `schemas/`, `test/fixtures/`
+  - [x] 0.7 Add dependency-direction lint rule or test: no import from `adapters/` inside `core/`
+  - [x] 0.8 Add core dependencies: `ajv`, `execa`, `typescript` (peer for AST); dev deps: `vitest`, `eslint`, `prettier`, pinned versions
+  - [x] 0.9 Verify local dev environment works: `pnpm install && pnpm run build && pnpm run test && pnpm run validate` all pass (empty test suite OK)
+  - [x] 0.10 Verify: `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck` pass clean
+
+- [ ] 1.0 Implement Story S-001 - https://github.com/llipe/dev-tasks/issues/33: Package scaffold with two binaries and layered core
+  - [x] 1.1 Create `core/exit-codes.ts` with the full enum (0-14) from spec §6.7; export as a const object
+  - [x] 1.2 Create `bin/dev-tasks.ts` — parse argv, route to `install|update|status|pin|doctor|--version`, print usage + exit 2 on unknown
+  - [x] 1.3 Create `bin/dt.ts` — parse argv, route to `extract|catalog|ctx|scope|init|verify|validate-component|--version`, print usage + exit 2 on unknown
+  - [x] 1.4 Wire shared CLI options (`--json`, `--meta-repo`, `-v`) via a common arg parser in `adapters/cli/`
+  - [x] 1.5 Add `"bin": { "dev-tasks": "./dist/bin/dev-tasks.js", "dt": "./dist/bin/dt.js" }` to `package.json`
+  - [x] 1.6 Create `core/index.ts` barrel export and per-module stubs (`core/catalog/index.ts`, `core/extract/index.ts`, etc.)
+  - [x] 1.7 Write unit tests: exit-code values; both binaries print usage on no-args; unknown command → exit 2; `--version` prints version
+  - [x] 1.8 Write integration test: `npx` invocation of both binaries in an isolated temp directory resolves
+  - [x] 1.9 Write dependency-direction test: assert no `adapters/` import path appears in any `core/` source file
+  - [x] 1.10 Verify Acceptance Criterion: `package.json` declares bin + engines correctly
+  - [x] 1.11 Verify Acceptance Criterion: directory layout matches spec §4.1
+  - [x] 1.12 Verify Acceptance Criterion: `core/` has no `adapters/` import
+  - [x] 1.13 Verify Acceptance Criterion: `npx` resolves both binaries
+  - [x] 1.14 Verify Acceptance Criterion: unknown command → exit 2
+  - [x] 1.15 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [x] 2.0 Implement Story S-002 - https://github.com/llipe/dev-tasks/issues/35: dev-tasks bootstrap — install, status, pin, doctor
+  - [x] 2.1 Implement `core/distribution/hash.ts` — SHA-256 of file content; deterministic, reusable by S-003 and S-009
+  - [x] 2.2 Implement `core/distribution/manifest.ts` — read/write `.dev-tasks/manifest.json` (schema per spec §5.5: version, pinned, installed_at, skills[], extraction)
+  - [x] 2.3 Implement `dev-tasks install [--pin <version>]` — copy skill files from the package into the target repo, compute sha256 + origin_sha256 per file, write manifest
+  - [x] 2.4 Implement `dev-tasks pin <version>` — write `.dev-tasks/version`; subsequent runs honor the pin
+  - [x] 2.5 Implement `dev-tasks status` — compare installed vs. pinned vs. latest-published versions; support `--json`
+  - [x] 2.6 Implement `core/distribution/doctor.ts` — check Node ≥20, git ≥2.37, cache dir writable, version skew; report pass/fail per check
+  - [x] 2.7 Wire `dev-tasks doctor` command with human + `--json` output
+  - [x] 2.8 Write unit tests: manifest read/write round-trip; pin resolution; version comparison; each doctor check in isolation
+  - [x] 2.9 Write integration test: `install` into a temp repo → expected file set + manifest; `pin` → `.dev-tasks/version` written; `status --json` output shape
+  - [x] 2.10 Verify Acceptance Criterion: install writes manifest with sha256/origin_sha256
+  - [x] 2.11 Verify Acceptance Criterion: pin is honored by subsequent runs
+  - [x] 2.12 Verify Acceptance Criterion: status reports all three versions
+  - [x] 2.13 Verify Acceptance Criterion: doctor checks Node/git/cache
+  - [x] 2.14 Verify Acceptance Criterion: all commands support --json
+  - [x] 2.15 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [ ] 3.0 Implement Story S-003 - https://github.com/llipe/dev-tasks/issues/34: Hash-based reconciliation engine and dev-tasks update
+  - [ ] 3.1 Implement `core/reconcile.ts` — generic reconciliation function: for each file determine action (install/overwrite/skip/conflict) based on local hash vs. origin hash vs. package hash
+  - [ ] 3.2 Implement `core/distribution/backup.ts` — timestamped backup directory creation under `.dev-tasks/backup/<ts>/`
+  - [ ] 3.3 Wire `dev-tasks update [--force]` — reconcile each skill file; without --force report conflicts + exit 14; with --force backup + overwrite
+  - [ ] 3.4 Emit deterministic conflict report: list conflicting paths with a diff summary; support `--json`
+  - [ ] 3.5 Ensure `core/reconcile.ts` is exported and importable by extraction (S-009) without circular dependency
+  - [ ] 3.6 Write unit tests: all four reconciliation branches (install/overwrite/skip/conflict); backup path generation
+  - [ ] 3.7 Write integration test: repo with one edited and one unedited skill → update reports conflict on edited only + exit 14; --force backs up + overwrites
+  - [ ] 3.8 Write edge-case tests: file deleted locally; file added to package; identical content different mtime; --force with unwritable backup dir → error
+  - [ ] 3.9 Verify Acceptance Criterion: four-branch reconciliation
+  - [ ] 3.10 Verify Acceptance Criterion: --force writes backup
+  - [ ] 3.11 Verify Acceptance Criterion: conflict → exit 14 + diff summary
+  - [ ] 3.12 Verify Acceptance Criterion: reconcile function is shared (import from core/ by extraction)
+  - [ ] 3.13 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [ ] 4.0 Implement Story S-004 - https://github.com/llipe/dev-tasks/issues/36: Migration shim from dev-tasks.sh
+  - [ ] 4.1 Implement `core/distribution/migrate.ts` — legacy detection logic (is the current install driven by the old shell script?)
+  - [ ] 4.2 Implement manifest generation from legacy state: compute hashes of already-installed files, mark all as `modified: unknown`
+  - [ ] 4.3 Replace `dev-tasks.sh` with the migration shim: detects legacy → installs `@llipe/dev-tasks` → writes manifest → prints npm-updates notice
+  - [ ] 4.4 Verify the first `dev-tasks update` after migration reports a conflict for pre-existing files (because `modified: unknown` maps to the conflict branch)
+  - [ ] 4.5 Document archival in `CHANGELOG.md` (breaking change: legacy self-update removed)
+  - [ ] 4.6 Write unit tests: legacy detection; manifest generation with `modified: unknown`
+  - [ ] 4.7 Write integration test: simulate legacy install dir → run shim → manifest written → first update yields conflicts
+  - [ ] 4.8 Write edge-case tests: no legacy install present (noop); partial legacy install; npm install failure → clean error, no partial manifest
+  - [ ] 4.9 Verify Acceptance Criterion: shim detects legacy
+  - [ ] 4.10 Verify Acceptance Criterion: manifest with `modified: unknown`
+  - [ ] 4.11 Verify Acceptance Criterion: first update reports conflicts
+  - [ ] 4.12 Verify Acceptance Criterion: npm-updates notice printed
+  - [ ] 4.13 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [ ] 5.0 Implement Story S-005 - https://github.com/llipe/dev-tasks/issues/37: dt extract detect and the pluggable extractor interface
+  - [ ] 5.1 Define `ExtractionProvider` interface in `core/extract/provider.ts`: `id`, `detect(repo: RepoContext): DetectionResult | null`, `capabilities: Capability[]`, optional `extractSchema/extractOpenApi/extractAsyncApi`
+  - [ ] 5.2 Define `Capability` enum/type: `openapi_native`, `openapi_ast`, `db_introspection`, `orm_ast`, `topic_ast`, `payload_typed`
+  - [ ] 5.3 Define `DetectionResult` type: `stack[]`, `http: {framework, openapi_strategy, evidence[]}`, `orm: {kind, schema_path}`, `messaging: {client, evidence[]}`, `type_hint`
+  - [ ] 5.4 Implement `core/extract/detect.ts` — orchestrator that loads registered providers, runs `detect()`, returns the first match (or null)
+  - [ ] 5.5 Implement `core/extract/providers/node-ts.ts` — Node/TS provider: inspect `package.json` deps, directory structure, config files; report framework (nestjs/express/fastify/hono), ORM (prisma/drizzle/typeorm), messaging (kafkajs), with evidence; report `openapi_strategy` per the matrix (route 1/2/3) and per-strategy count
+  - [ ] 5.6 Handle missing capability: mark artifact not-produced, record in `requires_human`; do not fail
+  - [ ] 5.7 Wire `dt extract detect` CLI command with human + `--json` output
+  - [ ] 5.8 Create fixture repos under `test/fixtures/extract/`: nestjs-prisma-kafkajs, express-drizzle, fastify-no-orm, hono-typeorm, no-framework
+  - [ ] 5.9 Write unit tests: per-signal detector functions (swagger dep, prisma config, kafkajs dep, express dep)
+  - [ ] 5.10 Write integration tests: each fixture repo → expected DetectionResult JSON snapshot
+  - [ ] 5.11 Write edge-case tests: no `package.json`; multiple ORMs; monorepo-shaped dir (detect single package)
+  - [ ] 5.12 Verify Acceptance Criterion: output includes stack/http/orm/messaging/type_hint
+  - [ ] 5.13 Verify Acceptance Criterion: per-strategy OpenAPI count reported even without route 2
+  - [ ] 5.14 Verify Acceptance Criterion: ExtractionProvider interface with id/detect/capabilities/optional extract
+  - [ ] 5.15 Verify Acceptance Criterion: missing capability → requires_human, no failure
+  - [ ] 5.16 Verify Acceptance Criterion: --json output
+  - [ ] 5.17 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [ ] 6.0 Implement Story S-006 - https://github.com/llipe/dev-tasks/issues/38: dt extract schema
+  - [ ] 6.1 Implement `core/extract/orm/prisma.ts` — parse `schema.prisma` AST: extract models, fields (type, nullability, attributes), relations, enums
+  - [ ] 6.2 Implement `core/extract/orm/drizzle.ts` — parse Drizzle table definitions via TypeScript Compiler API: extract tables, columns, types, constraints
+  - [ ] 6.3 Implement `core/extract/orm/typeorm.ts` — parse entity decorators via TypeScript Compiler API: extract entities, columns, relations
+  - [ ] 6.4 Implement `core/extract/schema.ts` — orchestrator: detect ORM from S-005, delegate to the right extractor, attach `source: introspected`
+  - [ ] 6.5 Implement optional `information_schema` reader behind `--db-url`: connect to dev DB, query tables/columns/constraints; attach `source: introspected`
+  - [ ] 6.6 Implement fallback: no ORM + no `--db-url` → if SQL migrations exist, use LLM to infer schema from them; mark `source: inferred`, `confidence: low`
+  - [ ] 6.7 Implement `core/extract/render/schema-md.ts` — render tables, columns (type + nullability), PK/FK, indexes, and a Mermaid ER diagram
+  - [ ] 6.8 Add LLM description pass: semantic table descriptions over extracted structure (never invent columns)
+  - [ ] 6.9 Wire `dt extract schema [--db-url]` CLI command
+  - [ ] 6.10 Create ORM fixture repos: prisma fixture, drizzle fixture, typeorm fixture, no-orm fixture
+  - [ ] 6.11 Write unit tests: per-ORM AST extraction; Mermaid rendering; nullability/PK/FK handling
+  - [ ] 6.12 Write integration tests: each fixture → expected `schema.md` structure (descriptions can be stubbed)
+  - [ ] 6.13 Write edge-case tests: no ORM + no --db-url; composite keys; self-referential FK; enum types
+  - [ ] 6.14 Verify Acceptance Criterion: Prisma/Drizzle/TypeORM marked `introspected`
+  - [ ] 6.15 Verify Acceptance Criterion: --db-url uses information_schema; without it, fallback or skip
+  - [ ] 6.16 Verify Acceptance Criterion: output includes tables, columns, PK/FK, indexes, Mermaid diagram
+  - [ ] 6.17 Verify Acceptance Criterion: LLM writes descriptions only; no invented columns
+  - [ ] 6.18 Verify Acceptance Criterion: DB introspection off by default
+  - [ ] 6.19 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [ ] 7.0 Implement Story S-007 - https://github.com/llipe/dev-tasks/issues/39: dt extract openapi (routes 1 and 3)
+  - [ ] 7.1 Implement `core/extract/openapi/route1.ts` — detect on-disk `openapi.yaml/json`; copy, normalize (resolve $refs, set openapi: 3.1.x), validate; attach `source: introspected`, `confidence: high`
+  - [ ] 7.2 Implement `core/extract/openapi/route3.ts` — AST route discovery:
+    - [ ] 7.2.1 Locate route registrations: Express `app|router.get|post|put|patch|delete(path, handler)`, Fastify same pattern, Hono `app.get(path, handler)` + `.route()` groupings, NestJS `@Controller/@Get/@Post` decorators
+    - [ ] 7.2.2 Resolve full path by composing router prefixes
+    - [ ] 7.2.3 Derive path params from the route pattern
+    - [ ] 7.2.4 Derive query/body params from handler type signature (TypeScript Compiler API); support zod schemas
+    - [ ] 7.2.5 Derive response schema from return type; mark `any`/`unknown` as schema-less
+    - [ ] 7.2.6 Report dynamically registered routes in `unresolved[]` (loops over config, spread arrays)
+  - [ ] 7.3 Add LLM pass: write only `summary`, `description`, `tags` per endpoint — nothing structural
+  - [ ] 7.4 Implement `core/extract/openapi/validate.ts` — validate output against OpenAPI 3.1 JSON Schema
+  - [ ] 7.5 Attach provenance: `source: inferred`, `confidence: medium` (typed handlers) / `low` (untyped)
+  - [ ] 7.6 Wire `dt extract openapi [--strategy auto|1|3]` CLI command; record selected strategy + confidence
+  - [ ] 7.7 Leave a capability hook for route 2 (isolated framework boot) — interface only, not implemented
+  - [ ] 7.8 Create fixtures: repo with committed openapi.yaml (route 1); Express + typed handlers (route 3); Fastify + zod (route 3); Hono (route 3); dynamic routes (unresolved)
+  - [ ] 7.9 Write unit tests: path composition; param/body type resolution; zod handling; response marking; unresolved detection
+  - [ ] 7.10 Write integration tests: each fixture → expected OpenAPI output + schema validation pass
+  - [ ] 7.11 Write edge-case tests: nested routers; dynamic route loop → unresolved; untyped handlers → low confidence; malformed on-disk spec → route 1 error
+  - [ ] 7.12 Verify Acceptance Criterion: route 1 copies + normalizes + introspected/high
+  - [ ] 7.13 Verify Acceptance Criterion: route 3 AST + typed params + zod + marks unknown responses
+  - [ ] 7.14 Verify Acceptance Criterion: LLM writes only summary/description/tags
+  - [ ] 7.15 Verify Acceptance Criterion: output validates against OpenAPI 3.1
+  - [ ] 7.16 Verify Acceptance Criterion: dynamic routes → unresolved[], not omitted
+  - [ ] 7.17 Verify Acceptance Criterion: --strategy selects route; confidence recorded
+  - [ ] 7.18 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [ ] 8.0 Implement Story S-008 - https://github.com/llipe/dev-tasks/issues/41: dt extract asyncapi (Kafka topic inventory + payloads)
+  - [ ] 8.1 Implement `core/extract/asyncapi/topics.ts` — AST over kafkajs:
+    - [ ] 8.1.1 `producer.send({ topic: X, messages })` → provides
+    - [ ] 8.1.2 `producer.sendBatch(...)` → provides
+    - [ ] 8.1.3 `consumer.subscribe({ topic: X })` → consumes
+    - [ ] 8.1.4 `consumer.subscribe({ topics: [X, Y] })` → consumes
+  - [ ] 8.2 Implement topic resolution with confidence:
+    - [ ] 8.2.1 String literal → high
+    - [ ] 8.2.2 Module constant or enum (follow reference in AST) → high
+    - [ ] 8.2.3 Template literal with env var → medium (record pattern + variable)
+    - [ ] 8.2.4 Unresolvable expression → low + entry in `unresolved[]`
+  - [ ] 8.3 Implement `core/extract/asyncapi/payloads.ts` — payload classification:
+    - [ ] 8.3.1 Typed `send()` (generic or interface in the signature) → medium, derive schema from the type
+    - [ ] 8.3.2 Inline object literal built at call site → low, LLM infers shape
+    - [ ] 8.3.3 Opaque serialization (`Buffer`, `JSON.stringify(variable)`) → low + `unresolved[]`
+  - [ ] 8.4 Emit AsyncAPI document with separate `topic_confidence` and `payload_confidence` per channel/operation
+  - [ ] 8.5 Implement `core/extract/asyncapi/validate.ts` — validate output against AsyncAPI schema
+  - [ ] 8.6 Wire `dt extract asyncapi` CLI command
+  - [ ] 8.7 Create fixtures: kafkajs with string-literal topics; topics from config/env; typed payloads; opaque payloads
+  - [ ] 8.8 Write unit tests: topic literal/constant/template/unresolvable resolution; payload typed/inline/opaque classification
+  - [ ] 8.9 Write integration tests: kafkajs fixture repos → expected topic inventory + confidence split + AsyncAPI validation
+  - [ ] 8.10 Write edge-case tests: `subscribe({ topics: [...] })`; topic from config array; Buffer payload → low + unresolved; producer with no consumers in the same repo
+  - [ ] 8.11 Verify Acceptance Criterion: producer.send/sendBatch → provides; subscribe → consumes
+  - [ ] 8.12 Verify Acceptance Criterion: topic confidence literal→high, template→medium, unresolvable→low+unresolved
+  - [ ] 8.13 Verify Acceptance Criterion: payload confidence typed→medium, inline→low, opaque→low+unresolved
+  - [ ] 8.14 Verify Acceptance Criterion: topic_confidence and payload_confidence tracked separately
+  - [ ] 8.15 Verify Acceptance Criterion: output validates against AsyncAPI schema
+  - [ ] 8.16 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+
+- [ ] 9.0 Implement Story S-009 - https://github.com/llipe/dev-tasks/issues/40: dt extract component — provenance, human gate, idempotency, report
+  - [ ] 9.1 Implement `core/extract/component.ts` — field-category derivation:
+    - [ ] 9.1.1 Derivable fields (`stack`, `type`, `provides[].path`, `datastores`, `paths`, `docs.*`, `consumes`) from detection + extraction outputs
+    - [ ] 9.1.2 Inferable fields (`description`, `aliases`, `subdomain`, `consumes[].criticality`) via LLM; require human confirmation before persisting
+    - [ ] 9.1.3 Non-derivable fields (`owner`, `domain`, `criticality`, `lifecycle`) via interactive prompt only
+  - [ ] 9.2 Implement `core/extract/prompt.ts` — interactive prompt for non-derivable fields (TTY detection; no-op when non-interactive; unanswered → empty)
+  - [ ] 9.3 Assemble `_provenance` block: `extracted_at`, `extractor` (dt version), `repo_sha`, `detector` result, per-field `source`/`confidence` (with `confirmed_by` for confirmed inferences), `field_hashes` (SHA-256 per serialized field value)
+  - [ ] 9.4 Wire idempotency through `core/reconcile.ts` (from S-003): for each field — write if absent, write if hash matches origin (unedited), skip if value equal, conflict otherwise
+  - [ ] 9.5 Implement `core/extract/report.ts` — `extraction_report.json` generation: strategies used, coverage (endpoints/topics/tables resolved vs. unresolved), confidence counts, `unresolved[]` with location + reason, `requires_human[]`
+  - [ ] 9.6 Implement `dt extract component [--interactive]` and `dt extract all [--interactive] [--force]` CLI commands
+  - [ ] 9.7 Orchestrate `extract all`: detect → schema → openapi → asyncapi → component → report; aggregate results; exit 13 if required fields unresolved, exit 14 on conflict
+  - [ ] 9.8 Create fixture: repo with prior extraction outputs ready for component derivation
+  - [ ] 9.9 Write unit tests: field-category routing; provenance assembly; field_hashes computation; report aggregation; reconcile integration
+  - [ ] 9.10 Write integration tests: full `extract all` on fixture → expected `component.yaml` + `extraction_report.json`; re-run → no rewrite (idempotent); edit a field + re-run → conflict
+  - [ ] 9.11 Write edge-case tests: unanswered prompts → empty + exit 13; --force overwrite; alias unconfirmed → not persisted; all-low-confidence repo → report reflects it
+  - [ ] 9.12 Verify Acceptance Criterion: derivable fields come from detection/extraction
+  - [ ] 9.13 Verify Acceptance Criterion: inferable fields require human confirmation; aliases not persisted without confirmation
+  - [ ] 9.14 Verify Acceptance Criterion: non-derivable fields prompted; unanswered → empty → invalid manifest
+  - [ ] 9.15 Verify Acceptance Criterion: every field/artifact carries source + confidence + _provenance
+  - [ ] 9.16 Verify Acceptance Criterion: idempotent re-run; edited fields → conflict + diff; no overwrite without --force
+  - [ ] 9.17 Verify Acceptance Criterion: extraction_report.json with strategies, coverage, confidence, unresolved, requires_human
+  - [ ] 9.18 Verify Acceptance Criterion: exit 13 on missing required fields; exit 14 on conflict
+  - [ ] 9.19 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`


### PR DESCRIPTION
## What

Implement S-002: dev-tasks bootstrap commands — `install`, `status`, `pin`, `doctor`.

## Why

These commands form the foundation of the dev-tasks distribution workflow. Users need to install skills into target repos, pin versions, check status, and validate their environment prerequisites.

## How

- `core/distribution/hash.ts` — SHA-256 hashing utility (reusable by S-003/S-009)
- `core/distribution/manifest.ts` — read/write `.dev-tasks/manifest.json`
- `core/distribution/install.ts` — copy skills from package, compute hashes, write manifest
- `core/distribution/pin.ts` — read/write `.dev-tasks/version` pin file
- `core/distribution/status.ts` — compare installed/pinned/latest versions
- `core/distribution/doctor.ts` — Node>=20, git>=2.37, cache writable, version skew checks
- `bin/dev-tasks.ts` — wire all commands with human + `--json` output
- `adapters/cli/parse-args.ts` — add `--pin` flag support

## Testing

- 60 unit tests (hash, manifest, install, pin, status, doctor)
- 13 integration tests (CLI end-to-end)
- All quality gates pass: typecheck, lint, format:check, audit

## Checklist

- [x] Tests written (test-first)
- [x] All tests passing
- [x] Typecheck passes
- [x] Lint passes
- [x] Format passes
- [x] Audit passes
- [x] All acceptance criteria verified

Closes #35
