### PR TITLE
feat: dt extract detect and pluggable extractor interface (#37)

### DIFF
--- a/adapters/cli/extract-detect.ts
+++ b/adapters/cli/extract-detect.ts
@@ -1,0 +1,128 @@
+/**
+ * CLI handler for `dt extract detect`.
+ * Outputs detection results in human-readable or JSON format.
+ */
+
+import { resolve } from "node:path";
+import {
+  runDetection,
+  registerProvider,
+  getRequiresHuman,
+  getMatchingProvider,
+} from "#core/extract/detect.js";
+import { nodeTsProvider } from "#core/extract/providers/node-ts.js";
+import type { Capability, DetectionResult, RequiresHumanEntry } from "#core/extract/provider.js";
+import { ExitCode } from "#core/exit-codes.js";
+
+/** All capabilities that could be desired for full extraction. */
+const ALL_CAPABILITIES: Capability[] = [
+  "openapi_native",
+  "openapi_ast",
+  "db_introspection",
+  "orm_ast",
+  "topic_ast",
+  "payload_typed",
+];
+
+export interface ExtractDetectOptions {
+  json: boolean;
+  targetDir?: string;
+}
+
+export interface ExtractDetectOutput {
+  detection: DetectionResult | null;
+  requires_human: RequiresHumanEntry[];
+}
+
+/**
+ * Run the extract detect command.
+ * Returns exit code.
+ */
+export function runExtractDetect(options: ExtractDetectOptions): number {
+  // Register providers
+  registerProvider(nodeTsProvider);
+
+  const rootDir = resolve(options.targetDir ?? process.cwd());
+  const detection = runDetection({ rootDir });
+
+  let requiresHuman: RequiresHumanEntry[] = [];
+
+  if (detection) {
+    const provider = getMatchingProvider({ rootDir });
+    if (provider) {
+      // Check which capabilities are missing
+      requiresHuman = getRequiresHuman(provider, ALL_CAPABILITIES);
+    }
+  }
+
+  const output: ExtractDetectOutput = {
+    detection,
+    requires_human: requiresHuman,
+  };
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+  } else {
+    printHumanOutput(output);
+  }
+
+  return ExitCode.Success;
+}
+
+function printHumanOutput(output: ExtractDetectOutput): void {
+  const { detection, requires_human } = output;
+
+  if (!detection) {
+    process.stderr.write("No supported stack detected in this repository.\n");
+    process.stderr.write("Ensure a package.json with recognized dependencies exists.\n");
+    return;
+  }
+
+  process.stdout.write("Stack Detection Results\n");
+  process.stdout.write("=======================\n\n");
+
+  process.stdout.write(`Stack: ${detection.stack.join(", ")}\n`);
+  process.stdout.write(`Type Hint: ${detection.type_hint}\n\n`);
+
+  if (detection.http) {
+    process.stdout.write("HTTP Framework\n");
+    process.stdout.write(`  Framework: ${detection.http.framework}\n`);
+    process.stdout.write(`  OpenAPI Strategy: ${detection.http.openapi_strategy}\n`);
+    process.stdout.write("  Strategy Counts:\n");
+    process.stdout.write(`    Route 1 (native): ${detection.http.strategy_counts.route1}\n`);
+    process.stdout.write(`    Route 2 (boot):   ${detection.http.strategy_counts.route2}\n`);
+    process.stdout.write(`    Route 3 (AST):    ${detection.http.strategy_counts.route3}\n`);
+    process.stdout.write("  Evidence:\n");
+    for (const ev of detection.http.evidence) {
+      process.stdout.write(`    - ${ev.signal} (${ev.location})`);
+      if (ev.detail) process.stdout.write(` — ${ev.detail}`);
+      process.stdout.write("\n");
+    }
+    process.stdout.write("\n");
+  }
+
+  if (detection.orm) {
+    process.stdout.write("ORM\n");
+    process.stdout.write(`  Kind: ${detection.orm.kind}\n`);
+    process.stdout.write(`  Schema Path: ${detection.orm.schema_path ?? "(not found)"}\n`);
+    process.stdout.write("\n");
+  }
+
+  if (detection.messaging) {
+    process.stdout.write("Messaging\n");
+    process.stdout.write(`  Client: ${detection.messaging.client}\n`);
+    process.stdout.write("  Evidence:\n");
+    for (const ev of detection.messaging.evidence) {
+      process.stdout.write(`    - ${ev.signal} (${ev.location})\n`);
+    }
+    process.stdout.write("\n");
+  }
+
+  if (requires_human.length > 0) {
+    process.stdout.write("Requires Human (missing capabilities)\n");
+    for (const entry of requires_human) {
+      process.stdout.write(`  - ${entry.artifact}: ${entry.reason}\n`);
+    }
+    process.stdout.write("\n");
+  }
+}

--- a/bin/dt.ts
+++ b/bin/dt.ts
@@ -80,6 +80,32 @@ if (!COMMANDS.includes(args.command as (typeof COMMANDS)[number])) {
   process.exit(ExitCode.InvalidUsage);
 }
 
-// Command routing — stubs for now
-process.stderr.write(`Command '${args.command}' is not yet implemented.\n`);
-process.exit(ExitCode.GeneralError);
+// Command routing
+if (args.command === "extract") {
+  const subcommand = args.positional[0];
+  if (subcommand === "detect") {
+    const { runExtractDetect } = await import("#adapters/cli/extract-detect.js");
+    const targetDir = args.positional[1]; // optional: path to repo
+    const exitCode = runExtractDetect({
+      json: args.flags.json,
+      targetDir,
+    });
+    process.exit(exitCode);
+  } else if (!subcommand) {
+    process.stderr.write("Usage: dt extract <subcommand>\n\n");
+    process.stderr.write("Subcommands:\n");
+    process.stderr.write("  detect    Detect repository stack and framework\n");
+    process.stderr.write("  schema    Extract database schema\n");
+    process.stderr.write("  openapi   Extract OpenAPI specification\n");
+    process.stderr.write("  asyncapi  Extract AsyncAPI specification\n");
+    process.stderr.write("  component Derive component.yaml\n");
+    process.stderr.write("  all       Run full extraction pipeline\n");
+    process.exit(ExitCode.InvalidUsage);
+  } else {
+    process.stderr.write(`Subcommand 'extract ${subcommand}' is not yet implemented.\n`);
+    process.exit(ExitCode.GeneralError);
+  }
+} else {
+  process.stderr.write(`Command '${args.command}' is not yet implemented.\n`);
+  process.exit(ExitCode.GeneralError);
+}

--- a/core/extract/detect.ts
+++ b/core/extract/detect.ts
@@ -1,0 +1,109 @@
+/**
+ * Detection orchestrator — loads registered providers, runs detect(), returns first match.
+ * Spec §8.1 — deterministic stack/framework/ORM/messaging detection.
+ */
+
+import type {
+  Capability,
+  DetectionResult,
+  ExtractionProvider,
+  RepoContext,
+  RequiresHumanEntry,
+} from "./provider.js";
+
+/** Registry of extraction providers, ordered by priority. */
+let providers: ExtractionProvider[] = [];
+
+/**
+ * Register an extraction provider.
+ * Providers are evaluated in registration order; first match wins.
+ */
+export function registerProvider(provider: ExtractionProvider): void {
+  providers.push(provider);
+}
+
+/**
+ * Clear all registered providers (used in testing).
+ */
+export function clearProviders(): void {
+  providers = [];
+}
+
+/**
+ * Get the list of registered providers.
+ */
+export function getProviders(): readonly ExtractionProvider[] {
+  return providers;
+}
+
+/**
+ * Run detection across all registered providers.
+ * Returns the DetectionResult from the first matching provider, or null if none match.
+ */
+export function runDetection(repo: RepoContext): DetectionResult | null {
+  for (const provider of providers) {
+    const result = provider.detect(repo);
+    if (result !== null) {
+      return result;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get the matching provider for a repo (the first whose detect() returns non-null).
+ */
+export function getMatchingProvider(repo: RepoContext): ExtractionProvider | null {
+  for (const provider of providers) {
+    const result = provider.detect(repo);
+    if (result !== null) {
+      return provider;
+    }
+  }
+  return null;
+}
+
+/**
+ * Given a provider and a list of desired capabilities, compute which artifacts
+ * cannot be produced and should be recorded in requires_human.
+ *
+ * This does NOT throw — missing capabilities are informational, not fatal.
+ */
+export function getRequiresHuman(
+  provider: ExtractionProvider,
+  desiredCapabilities: Capability[],
+): RequiresHumanEntry[] {
+  const entries: RequiresHumanEntry[] = [];
+
+  for (const cap of desiredCapabilities) {
+    if (!provider.capabilities.includes(cap)) {
+      entries.push({
+        artifact: capabilityToArtifact(cap),
+        reason: `Provider '${provider.id}' does not declare capability '${cap}'`,
+        missing_capability: cap,
+      });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Map a capability to the artifact it would produce.
+ */
+function capabilityToArtifact(cap: Capability): string {
+  switch (cap) {
+    case "openapi_native":
+      return "openapi.yaml";
+    case "openapi_ast":
+      return "openapi.yaml";
+    case "db_introspection":
+      return "schema.md";
+    case "orm_ast":
+      return "schema.md";
+    case "topic_ast":
+      return "asyncapi.yaml";
+    case "payload_typed":
+      return "asyncapi.yaml";
+  }
+}

--- a/core/extract/index.ts
+++ b/core/extract/index.ts
@@ -1,4 +1,26 @@
 /**
  * Extract module — component metadata extraction.
  */
-export {};
+export type {
+  Capability,
+  DetectionEvidence,
+  DetectionResult,
+  ExtractionProvider,
+  HttpDetection,
+  MessagingDetection,
+  OpenApiStrategy,
+  OrmDetection,
+  RepoContext,
+  RequiresHumanEntry,
+} from "./provider.js";
+
+export {
+  runDetection,
+  registerProvider,
+  clearProviders,
+  getProviders,
+  getMatchingProvider,
+  getRequiresHuman,
+} from "./detect.js";
+
+export { nodeTsProvider } from "./providers/node-ts.js";

--- a/core/extract/provider.ts
+++ b/core/extract/provider.ts
@@ -1,0 +1,137 @@
+/**
+ * Pluggable extraction provider interface and supporting types.
+ * Spec §4.8 — providers declare capabilities and implement detection + extraction.
+ */
+
+/**
+ * Capabilities a provider can declare.
+ * Each maps to a specific extraction strategy.
+ */
+export type Capability =
+  | "openapi_native" // Route 1: copy on-disk OpenAPI spec
+  | "openapi_ast" // Route 3: AST-based route discovery
+  | "db_introspection" // Direct DB schema introspection
+  | "orm_ast" // ORM AST extraction (prisma/drizzle/typeorm)
+  | "topic_ast" // Kafka topic AST extraction
+  | "payload_typed"; // Typed message payload extraction
+
+/**
+ * OpenAPI strategy identifiers per the detection matrix.
+ */
+export type OpenApiStrategy = "route1" | "route2" | "route3";
+
+/**
+ * Evidence entry for a detection signal.
+ */
+export interface DetectionEvidence {
+  /** What was detected (e.g. dependency name, file path, config key) */
+  signal: string;
+  /** Where it was found */
+  location: string;
+  /** Optional additional context */
+  detail?: string;
+}
+
+/**
+ * HTTP framework detection result.
+ */
+export interface HttpDetection {
+  /** Detected framework (nestjs, express, fastify, hono) */
+  framework: string;
+  /** Which OpenAPI strategy applies based on detection signals */
+  openapi_strategy: OpenApiStrategy;
+  /** Per-strategy evidence count */
+  strategy_counts: Record<OpenApiStrategy, number>;
+  /** Evidence supporting the detection */
+  evidence: DetectionEvidence[];
+}
+
+/**
+ * ORM detection result.
+ */
+export interface OrmDetection {
+  /** ORM kind (prisma, drizzle, typeorm) */
+  kind: string;
+  /** Path to schema file (e.g., prisma/schema.prisma) */
+  schema_path: string | null;
+}
+
+/**
+ * Messaging client detection result.
+ */
+export interface MessagingDetection {
+  /** Client library (kafkajs, etc.) */
+  client: string;
+  /** Evidence supporting the detection */
+  evidence: DetectionEvidence[];
+}
+
+/**
+ * Result of a provider's detect() call.
+ * Reports the full stack detection with evidence.
+ */
+export interface DetectionResult {
+  /** Detected stack components (e.g. ["node", "typescript", "nestjs", "prisma", "kafkajs"]) */
+  stack: string[];
+  /** HTTP framework detection (null if none detected) */
+  http: HttpDetection | null;
+  /** ORM detection (null if none detected) */
+  orm: OrmDetection | null;
+  /** Messaging client detection (null if none detected) */
+  messaging: MessagingDetection | null;
+  /** Type hint for the provider combination (e.g. "node-nestjs-prisma-kafkajs") */
+  type_hint: string;
+}
+
+/**
+ * Context provided to a provider's detect() method.
+ */
+export interface RepoContext {
+  /** Absolute path to the repository root */
+  rootDir: string;
+}
+
+/**
+ * Fields that require human input because the provider lacks the capability.
+ */
+export interface RequiresHumanEntry {
+  /** Artifact that could not be produced */
+  artifact: string;
+  /** Reason it could not be produced */
+  reason: string;
+  /** Which capability was missing */
+  missing_capability: Capability;
+}
+
+/**
+ * Pluggable extraction provider interface.
+ * Each provider targets a specific stack combination and declares its capabilities.
+ */
+export interface ExtractionProvider {
+  /** Unique provider identifier (e.g. "node-ts") */
+  id: string;
+
+  /** Capabilities this provider can perform */
+  capabilities: Capability[];
+
+  /**
+   * Detect whether this provider applies to the given repo.
+   * Returns a DetectionResult if the provider matches, null otherwise.
+   */
+  detect(repo: RepoContext): DetectionResult | null;
+
+  /**
+   * Extract database schema (optional — only if orm_ast or db_introspection capability declared).
+   */
+  extractSchema?(repo: RepoContext): Promise<unknown>;
+
+  /**
+   * Extract OpenAPI specification (optional — only if openapi_native or openapi_ast capability declared).
+   */
+  extractOpenApi?(repo: RepoContext): Promise<unknown>;
+
+  /**
+   * Extract AsyncAPI specification (optional — only if topic_ast or payload_typed capability declared).
+   */
+  extractAsyncApi?(repo: RepoContext): Promise<unknown>;
+}

--- a/core/extract/providers/node-ts.ts
+++ b/core/extract/providers/node-ts.ts
@@ -1,0 +1,387 @@
+/**
+ * Node/TypeScript extraction provider.
+ * Inspects package.json deps, directory structure, and config files to detect:
+ * - HTTP framework (nestjs, express, fastify, hono)
+ * - ORM (prisma, drizzle, typeorm)
+ * - Messaging (kafkajs)
+ *
+ * Reports openapi_strategy per the detection matrix (route 1/2/3)
+ * and per-strategy evidence count.
+ *
+ * Deterministic: pure config/file inspection, no LLM.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  Capability,
+  DetectionEvidence,
+  DetectionResult,
+  ExtractionProvider,
+  HttpDetection,
+  MessagingDetection,
+  OpenApiStrategy,
+  OrmDetection,
+  RepoContext,
+} from "../provider.js";
+
+// --- Signal detection functions (exported for unit testing) ---
+
+export interface PackageDeps {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+}
+
+/**
+ * Read and parse package.json from the given directory.
+ * Returns null if not found or invalid JSON.
+ */
+export function readPackageJson(rootDir: string): PackageDeps | null {
+  const pkgPath = join(rootDir, "package.json");
+  if (!existsSync(pkgPath)) {
+    return null;
+  }
+  try {
+    const raw = readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      dependencies: (pkg.dependencies as Record<string, string>) ?? {},
+      devDependencies: (pkg.devDependencies as Record<string, string>) ?? {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a dependency exists in either dependencies or devDependencies.
+ */
+export function hasDep(deps: PackageDeps, name: string): boolean {
+  return name in deps.dependencies || name in deps.devDependencies;
+}
+
+/**
+ * Check if any dependency matching a prefix exists.
+ */
+export function hasDepPrefix(deps: PackageDeps, prefix: string): boolean {
+  const allDeps = { ...deps.dependencies, ...deps.devDependencies };
+  return Object.keys(allDeps).some((k) => k.startsWith(prefix));
+}
+
+// --- Framework detection ---
+
+export interface FrameworkSignal {
+  framework: string;
+  dep: string;
+  location: string;
+}
+
+/**
+ * Detect HTTP framework from package.json dependencies.
+ */
+export function detectFramework(deps: PackageDeps): FrameworkSignal | null {
+  // Priority order: nestjs > fastify > hono > express
+  if (hasDepPrefix(deps, "@nestjs/")) {
+    return {
+      framework: "nestjs",
+      dep: "@nestjs/core",
+      location: "package.json",
+    };
+  }
+  if (hasDep(deps, "fastify")) {
+    return {
+      framework: "fastify",
+      dep: "fastify",
+      location: "package.json",
+    };
+  }
+  if (hasDep(deps, "hono")) {
+    return {
+      framework: "hono",
+      dep: "hono",
+      location: "package.json",
+    };
+  }
+  if (hasDep(deps, "express")) {
+    return {
+      framework: "express",
+      dep: "express",
+      location: "package.json",
+    };
+  }
+  return null;
+}
+
+// --- ORM detection ---
+
+export interface OrmSignal {
+  kind: string;
+  dep: string;
+  schemaPath: string | null;
+}
+
+/**
+ * Detect ORM from package.json dependencies and config file presence.
+ */
+export function detectOrm(deps: PackageDeps, rootDir: string): OrmSignal | null {
+  // Check Prisma
+  if (hasDep(deps, "@prisma/client") || hasDep(deps, "prisma")) {
+    const schemaPath = findPrismaSchema(rootDir);
+    return {
+      kind: "prisma",
+      dep: "@prisma/client",
+      schemaPath,
+    };
+  }
+
+  // Check Drizzle
+  if (hasDep(deps, "drizzle-orm") || hasDep(deps, "drizzle-kit")) {
+    const schemaPath = findDrizzleSchema(rootDir);
+    return {
+      kind: "drizzle",
+      dep: "drizzle-orm",
+      schemaPath,
+    };
+  }
+
+  // Check TypeORM
+  if (hasDep(deps, "typeorm")) {
+    return {
+      kind: "typeorm",
+      dep: "typeorm",
+      schemaPath: null, // TypeORM uses decorator-based entities
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Find Prisma schema file.
+ */
+function findPrismaSchema(rootDir: string): string | null {
+  const candidates = ["prisma/schema.prisma", "schema.prisma", "src/prisma/schema.prisma"];
+  for (const candidate of candidates) {
+    if (existsSync(join(rootDir, candidate))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find Drizzle schema path from config or conventions.
+ */
+function findDrizzleSchema(rootDir: string): string | null {
+  // Check drizzle.config.ts/js existence
+  const configCandidates = ["drizzle.config.ts", "drizzle.config.js", "drizzle.config.mjs"];
+  for (const candidate of configCandidates) {
+    if (existsSync(join(rootDir, candidate))) {
+      return candidate;
+    }
+  }
+
+  // Check common schema locations
+  const schemaCandidates = ["src/db/schema.ts", "src/schema.ts", "db/schema.ts"];
+  for (const candidate of schemaCandidates) {
+    if (existsSync(join(rootDir, candidate))) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+// --- Messaging detection ---
+
+export interface MessagingSignal {
+  client: string;
+  dep: string;
+}
+
+/**
+ * Detect messaging client from package.json dependencies.
+ */
+export function detectMessaging(deps: PackageDeps): MessagingSignal | null {
+  if (hasDep(deps, "kafkajs")) {
+    return { client: "kafkajs", dep: "kafkajs" };
+  }
+  return null;
+}
+
+// --- OpenAPI strategy detection ---
+
+/**
+ * Determine OpenAPI strategy based on framework detection and available signals.
+ */
+export function detectOpenApiStrategy(
+  framework: string,
+  deps: PackageDeps,
+  rootDir: string,
+): {
+  strategy: OpenApiStrategy;
+  counts: Record<OpenApiStrategy, number>;
+  evidence: DetectionEvidence[];
+} {
+  const counts: Record<OpenApiStrategy, number> = { route1: 0, route2: 0, route3: 0 };
+  const evidence: DetectionEvidence[] = [];
+
+  // Route 1: check for on-disk OpenAPI spec
+  const openapiFiles = [
+    "openapi.yaml",
+    "openapi.yml",
+    "openapi.json",
+    "swagger.yaml",
+    "swagger.yml",
+    "swagger.json",
+    "docs/openapi.yaml",
+    "docs/openapi.yml",
+    "docs/openapi.json",
+  ];
+  for (const file of openapiFiles) {
+    if (existsSync(join(rootDir, file))) {
+      counts.route1++;
+      evidence.push({
+        signal: "openapi_spec_file",
+        location: file,
+        detail: "On-disk OpenAPI specification found",
+      });
+    }
+  }
+
+  // Route 1 also: NestJS + @nestjs/swagger → can generate spec at build time
+  if (framework === "nestjs" && hasDep(deps, "@nestjs/swagger")) {
+    counts.route1++;
+    evidence.push({
+      signal: "@nestjs/swagger",
+      location: "package.json",
+      detail: "NestJS Swagger module — spec available at runtime/build",
+    });
+  }
+
+  // Route 3: AST-based route discovery (always available for known frameworks)
+  if (framework) {
+    counts.route3++;
+    evidence.push({
+      signal: `${framework}_routes`,
+      location: "source files",
+      detail: `AST route discovery available for ${framework}`,
+    });
+  }
+
+  // Determine primary strategy
+  let strategy: OpenApiStrategy;
+  if (counts.route1 > 0) {
+    strategy = "route1";
+  } else if (counts.route3 > 0) {
+    strategy = "route3";
+  } else {
+    strategy = "route3"; // Default for known frameworks
+  }
+
+  return { strategy, counts, evidence };
+}
+
+// --- Provider implementation ---
+
+/**
+ * Node/TypeScript extraction provider.
+ */
+export const nodeTsProvider: ExtractionProvider = {
+  id: "node-ts",
+
+  capabilities: [
+    "openapi_native",
+    "openapi_ast",
+    "orm_ast",
+    "topic_ast",
+    "payload_typed",
+  ] as Capability[],
+
+  detect(repo: RepoContext): DetectionResult | null {
+    const deps = readPackageJson(repo.rootDir);
+    if (!deps) {
+      return null;
+    }
+
+    // Must have TypeScript or be a Node project
+    const isNode =
+      hasDep(deps, "typescript") ||
+      hasDepPrefix(deps, "@types/") ||
+      Object.keys(deps.dependencies).length > 0 ||
+      Object.keys(deps.devDependencies).length > 0;
+
+    if (!isNode) {
+      return null;
+    }
+
+    // Detect stack components
+    const frameworkSignal = detectFramework(deps);
+    const ormSignal = detectOrm(deps, repo.rootDir);
+    const messagingSignal = detectMessaging(deps);
+
+    // If no framework, ORM, or messaging, this is a plain Node project — still valid
+    const stack: string[] = ["node"];
+    if (hasDep(deps, "typescript") || hasDepPrefix(deps, "@types/")) {
+      stack.push("typescript");
+    }
+
+    // Build detection sections
+    let http: HttpDetection | null = null;
+    if (frameworkSignal) {
+      stack.push(frameworkSignal.framework);
+      const openApiDetection = detectOpenApiStrategy(frameworkSignal.framework, deps, repo.rootDir);
+      http = {
+        framework: frameworkSignal.framework,
+        openapi_strategy: openApiDetection.strategy,
+        strategy_counts: openApiDetection.counts,
+        evidence: [
+          {
+            signal: frameworkSignal.dep,
+            location: frameworkSignal.location,
+          },
+          ...openApiDetection.evidence,
+        ],
+      };
+    }
+
+    let orm: OrmDetection | null = null;
+    if (ormSignal) {
+      stack.push(ormSignal.kind);
+      orm = {
+        kind: ormSignal.kind,
+        schema_path: ormSignal.schemaPath,
+      };
+    }
+
+    let messaging: MessagingDetection | null = null;
+    if (messagingSignal) {
+      stack.push(messagingSignal.client);
+      messaging = {
+        client: messagingSignal.client,
+        evidence: [
+          {
+            signal: messagingSignal.dep,
+            location: "package.json",
+          },
+        ],
+      };
+    }
+
+    // Build type_hint
+    const hintParts = ["node"];
+    if (frameworkSignal) hintParts.push(frameworkSignal.framework);
+    if (ormSignal) hintParts.push(ormSignal.kind);
+    if (messagingSignal) hintParts.push(messagingSignal.client);
+    if (hintParts.length === 1) hintParts.push("ts-no-framework");
+    const type_hint = hintParts.join("-");
+
+    return {
+      stack,
+      http,
+      orm,
+      messaging,
+      type_hint,
+    };
+  },
+};

--- a/test/fixtures/extract/express-drizzle/drizzle.config.ts
+++ b/test/fixtures/extract/express-drizzle/drizzle.config.ts
@@ -1,0 +1,4 @@
+export default {
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+};

--- a/test/fixtures/extract/express-drizzle/package.json
+++ b/test/fixtures/extract/express-drizzle/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "express-drizzle-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.18.0",
+    "drizzle-orm": "^0.30.0"
+  },
+  "devDependencies": {
+    "drizzle-kit": "^0.21.0",
+    "@types/express": "^4.17.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/test/fixtures/extract/express-drizzle/src/db/schema.ts
+++ b/test/fixtures/extract/express-drizzle/src/db/schema.ts
@@ -1,0 +1,2 @@
+// Drizzle schema file placeholder
+export {};

--- a/test/fixtures/extract/fastify-no-orm/package.json
+++ b/test/fixtures/extract/fastify-no-orm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fastify-no-orm-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "fastify": "^4.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/test/fixtures/extract/hono-typeorm/package.json
+++ b/test/fixtures/extract/hono-typeorm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hono-typeorm-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "hono": "^4.0.0",
+    "typeorm": "^0.3.0",
+    "reflect-metadata": "^0.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/test/fixtures/extract/nestjs-prisma-kafkajs/package.json
+++ b/test/fixtures/extract/nestjs-prisma-kafkajs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nestjs-prisma-kafkajs-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/swagger": "^7.0.0",
+    "@prisma/client": "^5.0.0",
+    "kafkajs": "^2.0.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/test/fixtures/extract/nestjs-prisma-kafkajs/prisma/schema.prisma
+++ b/test/fixtures/extract/nestjs-prisma-kafkajs/prisma/schema.prisma
@@ -1,0 +1,14 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+  name  String?
+}

--- a/test/fixtures/extract/no-framework/package.json
+++ b/test/fixtures/extract/no-framework/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "plain-node-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "lodash": "^4.17.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/test/integration/extract-detect-cli.test.ts
+++ b/test/integration/extract-detect-cli.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "../..");
+const FIXTURES_DIR = join(ROOT, "test/fixtures/extract");
+const TSX = join(ROOT, "node_modules/.bin/tsx");
+const DT_BIN = join(ROOT, "bin/dt.ts");
+
+function runDt(args: string[], cwd?: string): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync(TSX, [DT_BIN, ...args], {
+      cwd: cwd ?? ROOT,
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+      exitCode: error.status ?? 1,
+    };
+  }
+}
+
+describe("dt extract detect — CLI", () => {
+  it("outputs JSON for nestjs-prisma-kafkajs fixture", () => {
+    const { stdout, exitCode } = runDt([
+      "extract",
+      "detect",
+      FIXTURES_DIR + "/nestjs-prisma-kafkajs",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const output = JSON.parse(stdout);
+    expect(output.detection).not.toBeNull();
+    expect(output.detection.stack).toContain("nestjs");
+    expect(output.detection.http.framework).toBe("nestjs");
+    expect(output.detection.orm.kind).toBe("prisma");
+    expect(output.detection.messaging.client).toBe("kafkajs");
+    expect(output.detection.type_hint).toBe("node-nestjs-prisma-kafkajs");
+    expect(output.requires_human).toBeDefined();
+  });
+
+  it("outputs human-readable format by default", () => {
+    const { stdout, exitCode } = runDt(["extract", "detect", FIXTURES_DIR + "/express-drizzle"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Stack Detection Results");
+    expect(stdout).toContain("express");
+    expect(stdout).toContain("drizzle");
+  });
+
+  it("reports requires_human for missing capabilities in JSON", () => {
+    const { stdout, exitCode } = runDt([
+      "extract",
+      "detect",
+      FIXTURES_DIR + "/fastify-no-orm",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const output = JSON.parse(stdout);
+    expect(output.requires_human.length).toBeGreaterThan(0);
+    // db_introspection should be missing
+    const dbEntry = output.requires_human.find(
+      (e: { missing_capability: string }) => e.missing_capability === "db_introspection",
+    );
+    expect(dbEntry).toBeDefined();
+  });
+
+  it("handles no-framework repo", () => {
+    const { stdout, exitCode } = runDt([
+      "extract",
+      "detect",
+      FIXTURES_DIR + "/no-framework",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const output = JSON.parse(stdout);
+    expect(output.detection.http).toBeNull();
+    expect(output.detection.orm).toBeNull();
+    expect(output.detection.messaging).toBeNull();
+    expect(output.detection.type_hint).toBe("node-ts-no-framework");
+  });
+
+  it("outputs error message when no stack detected", () => {
+    const { exitCode } = runDt(["extract", "detect", "/tmp", "--json"]);
+    // /tmp won't have a package.json typically
+    expect(exitCode).toBe(0);
+  });
+
+  it("shows extract subcommand usage when no subcommand given", () => {
+    const { stderr, exitCode } = runDt(["extract"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("detect");
+  });
+});

--- a/test/integration/extract-detect.test.ts
+++ b/test/integration/extract-detect.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { join } from "node:path";
+import { runDetection, registerProvider, clearProviders } from "#core/extract/detect.js";
+import { nodeTsProvider } from "#core/extract/providers/node-ts.js";
+
+const FIXTURES_DIR = join(import.meta.dirname, "../fixtures/extract");
+
+describe("extract detect — integration (fixture repos)", () => {
+  beforeEach(() => {
+    clearProviders();
+    registerProvider(nodeTsProvider);
+  });
+
+  it("nestjs-prisma-kafkajs → full detection", () => {
+    const result = runDetection({
+      rootDir: join(FIXTURES_DIR, "nestjs-prisma-kafkajs"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.stack).toContain("node");
+    expect(result!.stack).toContain("nestjs");
+    expect(result!.stack).toContain("prisma");
+    expect(result!.stack).toContain("kafkajs");
+
+    // HTTP
+    expect(result!.http).not.toBeNull();
+    expect(result!.http!.framework).toBe("nestjs");
+    expect(result!.http!.openapi_strategy).toBe("route1");
+    expect(result!.http!.strategy_counts.route1).toBeGreaterThan(0);
+    expect(result!.http!.strategy_counts.route2).toBe(0);
+    expect(result!.http!.strategy_counts.route3).toBeGreaterThan(0);
+    expect(result!.http!.evidence.length).toBeGreaterThan(0);
+
+    // ORM
+    expect(result!.orm).not.toBeNull();
+    expect(result!.orm!.kind).toBe("prisma");
+    expect(result!.orm!.schema_path).toBe("prisma/schema.prisma");
+
+    // Messaging
+    expect(result!.messaging).not.toBeNull();
+    expect(result!.messaging!.client).toBe("kafkajs");
+    expect(result!.messaging!.evidence.length).toBeGreaterThan(0);
+
+    // type_hint
+    expect(result!.type_hint).toBe("node-nestjs-prisma-kafkajs");
+  });
+
+  it("express-drizzle → express + drizzle detection", () => {
+    const result = runDetection({
+      rootDir: join(FIXTURES_DIR, "express-drizzle"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.stack).toContain("node");
+    expect(result!.stack).toContain("typescript");
+    expect(result!.stack).toContain("express");
+    expect(result!.stack).toContain("drizzle");
+
+    expect(result!.http).not.toBeNull();
+    expect(result!.http!.framework).toBe("express");
+    expect(result!.http!.openapi_strategy).toBe("route3");
+
+    expect(result!.orm).not.toBeNull();
+    expect(result!.orm!.kind).toBe("drizzle");
+    expect(result!.orm!.schema_path).not.toBeNull();
+
+    expect(result!.messaging).toBeNull();
+    expect(result!.type_hint).toBe("node-express-drizzle");
+  });
+
+  it("fastify-no-orm → fastify only, no ORM/messaging", () => {
+    const result = runDetection({
+      rootDir: join(FIXTURES_DIR, "fastify-no-orm"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.stack).toContain("node");
+    expect(result!.stack).toContain("typescript");
+    expect(result!.stack).toContain("fastify");
+
+    expect(result!.http).not.toBeNull();
+    expect(result!.http!.framework).toBe("fastify");
+    expect(result!.http!.openapi_strategy).toBe("route3");
+
+    expect(result!.orm).toBeNull();
+    expect(result!.messaging).toBeNull();
+    expect(result!.type_hint).toBe("node-fastify");
+  });
+
+  it("hono-typeorm → hono + typeorm detection", () => {
+    const result = runDetection({
+      rootDir: join(FIXTURES_DIR, "hono-typeorm"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.stack).toContain("node");
+    expect(result!.stack).toContain("typescript");
+    expect(result!.stack).toContain("hono");
+    expect(result!.stack).toContain("typeorm");
+
+    expect(result!.http).not.toBeNull();
+    expect(result!.http!.framework).toBe("hono");
+
+    expect(result!.orm).not.toBeNull();
+    expect(result!.orm!.kind).toBe("typeorm");
+    expect(result!.orm!.schema_path).toBeNull(); // TypeORM uses decorators
+
+    expect(result!.messaging).toBeNull();
+    expect(result!.type_hint).toBe("node-hono-typeorm");
+  });
+
+  it("no-framework → plain node, no http/orm/messaging", () => {
+    const result = runDetection({
+      rootDir: join(FIXTURES_DIR, "no-framework"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.stack).toContain("node");
+    expect(result!.stack).toContain("typescript");
+
+    expect(result!.http).toBeNull();
+    expect(result!.orm).toBeNull();
+    expect(result!.messaging).toBeNull();
+    expect(result!.type_hint).toBe("node-ts-no-framework");
+  });
+
+  it("per-strategy OpenAPI count reported even without route 2", () => {
+    const result = runDetection({
+      rootDir: join(FIXTURES_DIR, "express-drizzle"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.http).not.toBeNull();
+    expect(result!.http!.strategy_counts).toHaveProperty("route1");
+    expect(result!.http!.strategy_counts).toHaveProperty("route2");
+    expect(result!.http!.strategy_counts).toHaveProperty("route3");
+    expect(result!.http!.strategy_counts.route2).toBe(0);
+  });
+});

--- a/test/unit/extract-detect-edge-cases.test.ts
+++ b/test/unit/extract-detect-edge-cases.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { join } from "node:path";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { runDetection, registerProvider, clearProviders } from "#core/extract/detect.js";
+import { nodeTsProvider } from "#core/extract/providers/node-ts.js";
+
+describe("extract detect — edge cases", () => {
+  beforeEach(() => {
+    clearProviders();
+    registerProvider(nodeTsProvider);
+  });
+
+  it("returns null when no package.json exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "no-pkg-"));
+    const result = runDetection({ rootDir: dir });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for invalid JSON in package.json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "bad-json-"));
+    writeFileSync(join(dir, "package.json"), "{ invalid json }");
+    const result = runDetection({ rootDir: dir });
+    expect(result).toBeNull();
+  });
+
+  it("handles package.json with empty dependencies", () => {
+    const dir = mkdtempSync(join(tmpdir(), "empty-deps-"));
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "empty", version: "1.0.0" }));
+    // No dependencies at all — should still detect as a Node project (package.json exists)
+    // but won't have TS, framework, ORM, or messaging
+    const result = runDetection({ rootDir: dir });
+    // With no deps at all, the object is empty — isNode checks for any key
+    expect(result).toBeNull();
+  });
+
+  it("detects multiple ORMs — returns first match (prisma priority)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "multi-orm-"));
+    mkdirSync(join(dir, "prisma"), { recursive: true });
+    writeFileSync(join(dir, "prisma/schema.prisma"), "model User {}");
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "multi-orm",
+        version: "1.0.0",
+        dependencies: {
+          "@prisma/client": "^5.0.0",
+          "drizzle-orm": "^0.30.0",
+          typeorm: "^0.3.0",
+          express: "^4.18.0",
+        },
+        devDependencies: {
+          prisma: "^5.0.0",
+          typescript: "^5.0.0",
+        },
+      }),
+    );
+
+    const result = runDetection({ rootDir: dir });
+    expect(result).not.toBeNull();
+    // Prisma has priority
+    expect(result!.orm!.kind).toBe("prisma");
+    expect(result!.orm!.schema_path).toBe("prisma/schema.prisma");
+  });
+
+  it("handles monorepo-shaped dir — detects single package at root", () => {
+    const dir = mkdtempSync(join(tmpdir(), "monorepo-"));
+    // Root has a package.json (workspace root)
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "monorepo-root",
+        version: "1.0.0",
+        private: true,
+        dependencies: {},
+        devDependencies: { typescript: "^5.0.0" },
+      }),
+    );
+    // A sub-package with nestjs
+    mkdirSync(join(dir, "packages/api"), { recursive: true });
+    writeFileSync(
+      join(dir, "packages/api/package.json"),
+      JSON.stringify({
+        name: "@monorepo/api",
+        dependencies: { "@nestjs/core": "^10.0.0" },
+      }),
+    );
+
+    // Detection at root level — sees only root package.json
+    const result = runDetection({ rootDir: dir });
+    expect(result).not.toBeNull();
+    // Root has only TS, no framework
+    expect(result!.http).toBeNull();
+    expect(result!.type_hint).toBe("node-ts-no-framework");
+  });
+
+  it("detects project with only devDependencies as a Node project", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dev-deps-"));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "dev-only",
+        version: "1.0.0",
+        devDependencies: {
+          typescript: "^5.0.0",
+          express: "^4.18.0",
+        },
+      }),
+    );
+
+    const result = runDetection({ rootDir: dir });
+    expect(result).not.toBeNull();
+    expect(result!.stack).toContain("typescript");
+    expect(result!.http).not.toBeNull();
+    expect(result!.http!.framework).toBe("express");
+  });
+
+  it("handles Prisma without schema file present", () => {
+    const dir = mkdtempSync(join(tmpdir(), "prisma-no-schema-"));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "no-schema",
+        version: "1.0.0",
+        dependencies: { "@prisma/client": "^5.0.0", express: "^4.18.0" },
+        devDependencies: { typescript: "^5.0.0" },
+      }),
+    );
+
+    const result = runDetection({ rootDir: dir });
+    expect(result).not.toBeNull();
+    expect(result!.orm!.kind).toBe("prisma");
+    expect(result!.orm!.schema_path).toBeNull();
+  });
+});

--- a/test/unit/extract-detect.test.ts
+++ b/test/unit/extract-detect.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  runDetection,
+  registerProvider,
+  clearProviders,
+  getRequiresHuman,
+} from "#core/extract/detect.js";
+import type {
+  ExtractionProvider,
+  DetectionResult,
+  RepoContext,
+  RequiresHumanEntry,
+} from "#core/extract/provider.js";
+
+function makeProvider(id: string, result: DetectionResult | null): ExtractionProvider {
+  return {
+    id,
+    capabilities: ["openapi_ast", "orm_ast"],
+    detect(_repo: RepoContext): DetectionResult | null {
+      return result;
+    },
+  };
+}
+
+describe("extract/detect orchestrator", () => {
+  beforeEach(() => {
+    clearProviders();
+  });
+
+  it("returns null when no providers are registered", () => {
+    const result = runDetection({ rootDir: "/tmp/empty" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no provider matches", () => {
+    registerProvider(makeProvider("no-match", null));
+    const result = runDetection({ rootDir: "/tmp/empty" });
+    expect(result).toBeNull();
+  });
+
+  it("returns the first matching provider result", () => {
+    const detection: DetectionResult = {
+      stack: ["node", "typescript"],
+      http: null,
+      orm: null,
+      messaging: null,
+      type_hint: "node-ts",
+    };
+    registerProvider(makeProvider("first", detection));
+    registerProvider(makeProvider("second", null));
+
+    const result = runDetection({ rootDir: "/tmp/repo" });
+    expect(result).toEqual(detection);
+  });
+
+  it("skips non-matching providers and returns the first match", () => {
+    const detection: DetectionResult = {
+      stack: ["node", "typescript", "express"],
+      http: {
+        framework: "express",
+        openapi_strategy: "route3",
+        strategy_counts: { route1: 0, route2: 0, route3: 5 },
+        evidence: [{ signal: "express", location: "package.json" }],
+      },
+      orm: null,
+      messaging: null,
+      type_hint: "node-express",
+    };
+    registerProvider(makeProvider("skip-me", null));
+    registerProvider(makeProvider("match-me", detection));
+
+    const result = runDetection({ rootDir: "/tmp/repo" });
+    expect(result).toEqual(detection);
+  });
+
+  it("handles missing capability by recording requires_human", () => {
+    const provider: ExtractionProvider = {
+      id: "limited-provider",
+      capabilities: ["openapi_ast"], // missing orm_ast, topic_ast
+      detect(_repo: RepoContext): DetectionResult | null {
+        return {
+          stack: ["node"],
+          http: {
+            framework: "express",
+            openapi_strategy: "route3",
+            strategy_counts: { route1: 0, route2: 0, route3: 3 },
+            evidence: [{ signal: "express", location: "package.json" }],
+          },
+          orm: null,
+          messaging: null,
+          type_hint: "node-express",
+        };
+      },
+    };
+    registerProvider(provider);
+
+    const result = runDetection({ rootDir: "/tmp/repo" });
+    expect(result).not.toBeNull();
+
+    // Test the requires_human helper
+    const requiredCapabilities: RequiresHumanEntry[] = getRequiresHuman(provider, [
+      "orm_ast",
+      "topic_ast",
+    ]);
+    expect(requiredCapabilities).toHaveLength(2);
+    expect(requiredCapabilities[0].missing_capability).toBe("orm_ast");
+    expect(requiredCapabilities[1].missing_capability).toBe("topic_ast");
+  });
+
+  it("does not fail when a provider lacks a capability", () => {
+    const provider: ExtractionProvider = {
+      id: "no-schema-provider",
+      capabilities: ["openapi_ast"], // no orm_ast
+      detect(_repo: RepoContext): DetectionResult | null {
+        return {
+          stack: ["node"],
+          http: null,
+          orm: null,
+          messaging: null,
+          type_hint: "node",
+        };
+      },
+      // extractSchema not defined — this is valid
+    };
+    registerProvider(provider);
+
+    // Should not throw
+    expect(() => runDetection({ rootDir: "/tmp/repo" })).not.toThrow();
+    const result = runDetection({ rootDir: "/tmp/repo" });
+    expect(result).not.toBeNull();
+  });
+});

--- a/test/unit/extract-node-ts-signals.test.ts
+++ b/test/unit/extract-node-ts-signals.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { join } from "node:path";
+import {
+  detectFramework,
+  detectOrm,
+  detectMessaging,
+  detectOpenApiStrategy,
+  hasDep,
+  hasDepPrefix,
+  readPackageJson,
+  type PackageDeps,
+} from "#core/extract/providers/node-ts.js";
+
+const FIXTURES_DIR = join(import.meta.dirname, "../fixtures/extract");
+
+describe("Node/TS provider — per-signal detectors", () => {
+  describe("readPackageJson", () => {
+    it("reads a valid package.json", () => {
+      const deps = readPackageJson(join(FIXTURES_DIR, "nestjs-prisma-kafkajs"));
+      expect(deps).not.toBeNull();
+      expect(deps!.dependencies).toHaveProperty("@nestjs/core");
+    });
+
+    it("returns null when package.json does not exist", () => {
+      const deps = readPackageJson("/nonexistent/path");
+      expect(deps).toBeNull();
+    });
+  });
+
+  describe("hasDep / hasDepPrefix", () => {
+    const deps: PackageDeps = {
+      dependencies: { express: "^4.18.0" },
+      devDependencies: { typescript: "^5.0.0" },
+    };
+
+    it("detects dependency in dependencies", () => {
+      expect(hasDep(deps, "express")).toBe(true);
+    });
+
+    it("detects dependency in devDependencies", () => {
+      expect(hasDep(deps, "typescript")).toBe(true);
+    });
+
+    it("returns false for missing dependency", () => {
+      expect(hasDep(deps, "fastify")).toBe(false);
+    });
+
+    it("detects dep prefix", () => {
+      const nestDeps: PackageDeps = {
+        dependencies: { "@nestjs/core": "^10.0.0" },
+        devDependencies: {},
+      };
+      expect(hasDepPrefix(nestDeps, "@nestjs/")).toBe(true);
+    });
+  });
+
+  describe("detectFramework", () => {
+    it("detects NestJS via @nestjs/ prefix", () => {
+      const deps: PackageDeps = {
+        dependencies: { "@nestjs/core": "^10.0.0", "@nestjs/common": "^10.0.0" },
+        devDependencies: {},
+      };
+      const result = detectFramework(deps);
+      expect(result).not.toBeNull();
+      expect(result!.framework).toBe("nestjs");
+    });
+
+    it("detects Express", () => {
+      const deps: PackageDeps = {
+        dependencies: { express: "^4.18.0" },
+        devDependencies: {},
+      };
+      const result = detectFramework(deps);
+      expect(result).not.toBeNull();
+      expect(result!.framework).toBe("express");
+    });
+
+    it("detects Fastify", () => {
+      const deps: PackageDeps = {
+        dependencies: { fastify: "^4.0.0" },
+        devDependencies: {},
+      };
+      const result = detectFramework(deps);
+      expect(result).not.toBeNull();
+      expect(result!.framework).toBe("fastify");
+    });
+
+    it("detects Hono", () => {
+      const deps: PackageDeps = {
+        dependencies: { hono: "^4.0.0" },
+        devDependencies: {},
+      };
+      const result = detectFramework(deps);
+      expect(result).not.toBeNull();
+      expect(result!.framework).toBe("hono");
+    });
+
+    it("returns null for no framework", () => {
+      const deps: PackageDeps = {
+        dependencies: { lodash: "^4.17.0" },
+        devDependencies: {},
+      };
+      const result = detectFramework(deps);
+      expect(result).toBeNull();
+    });
+
+    it("prioritizes NestJS over Express when both present", () => {
+      const deps: PackageDeps = {
+        dependencies: {
+          "@nestjs/core": "^10.0.0",
+          express: "^4.18.0",
+        },
+        devDependencies: {},
+      };
+      const result = detectFramework(deps);
+      expect(result!.framework).toBe("nestjs");
+    });
+  });
+
+  describe("detectOrm", () => {
+    it("detects Prisma via @prisma/client", () => {
+      const deps: PackageDeps = {
+        dependencies: { "@prisma/client": "^5.0.0" },
+        devDependencies: { prisma: "^5.0.0" },
+      };
+      const result = detectOrm(deps, join(FIXTURES_DIR, "nestjs-prisma-kafkajs"));
+      expect(result).not.toBeNull();
+      expect(result!.kind).toBe("prisma");
+      expect(result!.schemaPath).toBe("prisma/schema.prisma");
+    });
+
+    it("detects Drizzle via drizzle-orm", () => {
+      const deps: PackageDeps = {
+        dependencies: { "drizzle-orm": "^0.30.0" },
+        devDependencies: { "drizzle-kit": "^0.21.0" },
+      };
+      const result = detectOrm(deps, join(FIXTURES_DIR, "express-drizzle"));
+      expect(result).not.toBeNull();
+      expect(result!.kind).toBe("drizzle");
+      expect(result!.schemaPath).not.toBeNull();
+    });
+
+    it("detects TypeORM", () => {
+      const deps: PackageDeps = {
+        dependencies: { typeorm: "^0.3.0" },
+        devDependencies: {},
+      };
+      const result = detectOrm(deps, join(FIXTURES_DIR, "hono-typeorm"));
+      expect(result).not.toBeNull();
+      expect(result!.kind).toBe("typeorm");
+      expect(result!.schemaPath).toBeNull(); // TypeORM uses decorators
+    });
+
+    it("returns null when no ORM found", () => {
+      const deps: PackageDeps = {
+        dependencies: { fastify: "^4.0.0" },
+        devDependencies: {},
+      };
+      const result = detectOrm(deps, join(FIXTURES_DIR, "fastify-no-orm"));
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("detectMessaging", () => {
+    it("detects kafkajs", () => {
+      const deps: PackageDeps = {
+        dependencies: { kafkajs: "^2.0.0" },
+        devDependencies: {},
+      };
+      const result = detectMessaging(deps);
+      expect(result).not.toBeNull();
+      expect(result!.client).toBe("kafkajs");
+    });
+
+    it("returns null when no messaging client found", () => {
+      const deps: PackageDeps = {
+        dependencies: { express: "^4.18.0" },
+        devDependencies: {},
+      };
+      const result = detectMessaging(deps);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("detectOpenApiStrategy", () => {
+    it("detects route 1 for NestJS with @nestjs/swagger", () => {
+      const deps: PackageDeps = {
+        dependencies: { "@nestjs/swagger": "^7.0.0" },
+        devDependencies: {},
+      };
+      const result = detectOpenApiStrategy(
+        "nestjs",
+        deps,
+        join(FIXTURES_DIR, "nestjs-prisma-kafkajs"),
+      );
+      expect(result.strategy).toBe("route1");
+      expect(result.counts.route1).toBeGreaterThan(0);
+      expect(result.evidence.length).toBeGreaterThan(0);
+    });
+
+    it("detects route 3 for Express without on-disk spec", () => {
+      const deps: PackageDeps = {
+        dependencies: { express: "^4.18.0" },
+        devDependencies: {},
+      };
+      const result = detectOpenApiStrategy("express", deps, join(FIXTURES_DIR, "express-drizzle"));
+      expect(result.strategy).toBe("route3");
+      expect(result.counts.route3).toBeGreaterThan(0);
+    });
+
+    it("always reports route2 count as 0 (not yet implemented)", () => {
+      const deps: PackageDeps = {
+        dependencies: { fastify: "^4.0.0" },
+        devDependencies: {},
+      };
+      const result = detectOpenApiStrategy("fastify", deps, join(FIXTURES_DIR, "fastify-no-orm"));
+      expect(result.counts.route2).toBe(0);
+    });
+  });
+});

--- a/test/unit/extract-provider.test.ts
+++ b/test/unit/extract-provider.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import type {
+  Capability,
+  ExtractionProvider,
+  DetectionResult,
+  RepoContext,
+  RequiresHumanEntry,
+} from "#core/extract/provider.js";
+
+describe("ExtractionProvider interface and types", () => {
+  describe("Capability type", () => {
+    it("allows all valid capability values", () => {
+      const capabilities: Capability[] = [
+        "openapi_native",
+        "openapi_ast",
+        "db_introspection",
+        "orm_ast",
+        "topic_ast",
+        "payload_typed",
+      ];
+      expect(capabilities).toHaveLength(6);
+    });
+  });
+
+  describe("DetectionResult type", () => {
+    it("includes stack, http, orm, messaging, and type_hint fields", () => {
+      const result: DetectionResult = {
+        stack: ["node", "typescript", "nestjs"],
+        http: {
+          framework: "nestjs",
+          openapi_strategy: "route1",
+          strategy_counts: { route1: 1, route2: 0, route3: 1 },
+          evidence: [{ signal: "@nestjs/swagger", location: "package.json" }],
+        },
+        orm: {
+          kind: "prisma",
+          schema_path: "prisma/schema.prisma",
+        },
+        messaging: {
+          client: "kafkajs",
+          evidence: [{ signal: "kafkajs", location: "package.json" }],
+        },
+        type_hint: "node-nestjs-prisma-kafkajs",
+      };
+
+      expect(result.stack).toContain("node");
+      expect(result.http?.framework).toBe("nestjs");
+      expect(result.http?.openapi_strategy).toBe("route1");
+      expect(result.http?.strategy_counts).toHaveProperty("route1");
+      expect(result.http?.strategy_counts).toHaveProperty("route2");
+      expect(result.http?.strategy_counts).toHaveProperty("route3");
+      expect(result.orm?.kind).toBe("prisma");
+      expect(result.orm?.schema_path).toBe("prisma/schema.prisma");
+      expect(result.messaging?.client).toBe("kafkajs");
+      expect(result.type_hint).toBe("node-nestjs-prisma-kafkajs");
+    });
+
+    it("allows null for optional sections", () => {
+      const result: DetectionResult = {
+        stack: ["node", "typescript"],
+        http: null,
+        orm: null,
+        messaging: null,
+        type_hint: "node-ts-no-framework",
+      };
+
+      expect(result.http).toBeNull();
+      expect(result.orm).toBeNull();
+      expect(result.messaging).toBeNull();
+    });
+
+    it("reports per-strategy OpenAPI count even without route 2", () => {
+      const result: DetectionResult = {
+        stack: ["node", "typescript", "express"],
+        http: {
+          framework: "express",
+          openapi_strategy: "route3",
+          strategy_counts: { route1: 0, route2: 0, route3: 15 },
+          evidence: [{ signal: "express", location: "package.json" }],
+        },
+        orm: null,
+        messaging: null,
+        type_hint: "node-express",
+      };
+
+      expect(result.http!.strategy_counts.route2).toBe(0);
+      expect(result.http!.strategy_counts.route3).toBe(15);
+    });
+  });
+
+  describe("ExtractionProvider interface", () => {
+    it("declares id, detect, capabilities, and optional extract methods", () => {
+      const provider: ExtractionProvider = {
+        id: "test-provider",
+        capabilities: ["openapi_ast", "orm_ast"],
+        detect(_repo: RepoContext): DetectionResult | null {
+          return null;
+        },
+      };
+
+      expect(provider.id).toBe("test-provider");
+      expect(provider.capabilities).toContain("openapi_ast");
+      expect(provider.detect({ rootDir: "/tmp" })).toBeNull();
+      // Optional methods not present — that's valid
+      expect(provider.extractSchema).toBeUndefined();
+      expect(provider.extractOpenApi).toBeUndefined();
+      expect(provider.extractAsyncApi).toBeUndefined();
+    });
+
+    it("allows optional extract methods to be defined", () => {
+      const provider: ExtractionProvider = {
+        id: "full-provider",
+        capabilities: ["openapi_ast", "orm_ast", "topic_ast"],
+        detect(_repo: RepoContext): DetectionResult | null {
+          return {
+            stack: ["node"],
+            http: null,
+            orm: null,
+            messaging: null,
+            type_hint: "node",
+          };
+        },
+        async extractSchema(_repo: RepoContext) {
+          return { tables: [] };
+        },
+        async extractOpenApi(_repo: RepoContext) {
+          return { openapi: "3.1.0", paths: {} };
+        },
+        async extractAsyncApi(_repo: RepoContext) {
+          return { asyncapi: "3.0.0", channels: {} };
+        },
+      };
+
+      expect(provider.extractSchema).toBeDefined();
+      expect(provider.extractOpenApi).toBeDefined();
+      expect(provider.extractAsyncApi).toBeDefined();
+    });
+  });
+
+  describe("RequiresHumanEntry type", () => {
+    it("records missing capability information", () => {
+      const entry: RequiresHumanEntry = {
+        artifact: "openapi.yaml",
+        reason: "No OpenAPI spec found and no route discovery capability",
+        missing_capability: "openapi_native",
+      };
+
+      expect(entry.artifact).toBe("openapi.yaml");
+      expect(entry.missing_capability).toBe("openapi_native");
+    });
+  });
+});

--- a/workstream/tasks-multi-repo-context-plan.md
+++ b/workstream/tasks-multi-repo-context-plan.md
@@ -119,24 +119,24 @@
   - [x] 4.12 Verify Acceptance Criterion: npm-updates notice printed
   - [x] 4.13 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
 
-- [ ] 5.0 Implement Story S-005 - https://github.com/llipe/dev-tasks/issues/37: dt extract detect and the pluggable extractor interface
-  - [ ] 5.1 Define `ExtractionProvider` interface in `core/extract/provider.ts`: `id`, `detect(repo: RepoContext): DetectionResult | null`, `capabilities: Capability[]`, optional `extractSchema/extractOpenApi/extractAsyncApi`
-  - [ ] 5.2 Define `Capability` enum/type: `openapi_native`, `openapi_ast`, `db_introspection`, `orm_ast`, `topic_ast`, `payload_typed`
-  - [ ] 5.3 Define `DetectionResult` type: `stack[]`, `http: {framework, openapi_strategy, evidence[]}`, `orm: {kind, schema_path}`, `messaging: {client, evidence[]}`, `type_hint`
-  - [ ] 5.4 Implement `core/extract/detect.ts` — orchestrator that loads registered providers, runs `detect()`, returns the first match (or null)
-  - [ ] 5.5 Implement `core/extract/providers/node-ts.ts` — Node/TS provider: inspect `package.json` deps, directory structure, config files; report framework (nestjs/express/fastify/hono), ORM (prisma/drizzle/typeorm), messaging (kafkajs), with evidence; report `openapi_strategy` per the matrix (route 1/2/3) and per-strategy count
-  - [ ] 5.6 Handle missing capability: mark artifact not-produced, record in `requires_human`; do not fail
-  - [ ] 5.7 Wire `dt extract detect` CLI command with human + `--json` output
-  - [ ] 5.8 Create fixture repos under `test/fixtures/extract/`: nestjs-prisma-kafkajs, express-drizzle, fastify-no-orm, hono-typeorm, no-framework
-  - [ ] 5.9 Write unit tests: per-signal detector functions (swagger dep, prisma config, kafkajs dep, express dep)
-  - [ ] 5.10 Write integration tests: each fixture repo → expected DetectionResult JSON snapshot
-  - [ ] 5.11 Write edge-case tests: no `package.json`; multiple ORMs; monorepo-shaped dir (detect single package)
-  - [ ] 5.12 Verify Acceptance Criterion: output includes stack/http/orm/messaging/type_hint
-  - [ ] 5.13 Verify Acceptance Criterion: per-strategy OpenAPI count reported even without route 2
-  - [ ] 5.14 Verify Acceptance Criterion: ExtractionProvider interface with id/detect/capabilities/optional extract
-  - [ ] 5.15 Verify Acceptance Criterion: missing capability → requires_human, no failure
-  - [ ] 5.16 Verify Acceptance Criterion: --json output
-  - [ ] 5.17 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
+- [x] 5.0 Implement Story S-005 - https://github.com/llipe/dev-tasks/issues/37: dt extract detect and the pluggable extractor interface
+  - [x] 5.1 Define `ExtractionProvider` interface in `core/extract/provider.ts`: `id`, `detect(repo: RepoContext): DetectionResult | null`, `capabilities: Capability[]`, optional `extractSchema/extractOpenApi/extractAsyncApi`
+  - [x] 5.2 Define `Capability` enum/type: `openapi_native`, `openapi_ast`, `db_introspection`, `orm_ast`, `topic_ast`, `payload_typed`
+  - [x] 5.3 Define `DetectionResult` type: `stack[]`, `http: {framework, openapi_strategy, evidence[]}`, `orm: {kind, schema_path}`, `messaging: {client, evidence[]}`, `type_hint`
+  - [x] 5.4 Implement `core/extract/detect.ts` — orchestrator that loads registered providers, runs `detect()`, returns the first match (or null)
+  - [x] 5.5 Implement `core/extract/providers/node-ts.ts` — Node/TS provider: inspect `package.json` deps, directory structure, config files; report framework (nestjs/express/fastify/hono), ORM (prisma/drizzle/typeorm), messaging (kafkajs), with evidence; report `openapi_strategy` per the matrix (route 1/2/3) and per-strategy count
+  - [x] 5.6 Handle missing capability: mark artifact not-produced, record in `requires_human`; do not fail
+  - [x] 5.7 Wire `dt extract detect` CLI command with human + `--json` output
+  - [x] 5.8 Create fixture repos under `test/fixtures/extract/`: nestjs-prisma-kafkajs, express-drizzle, fastify-no-orm, hono-typeorm, no-framework
+  - [x] 5.9 Write unit tests: per-signal detector functions (swagger dep, prisma config, kafkajs dep, express dep)
+  - [x] 5.10 Write integration tests: each fixture repo → expected DetectionResult JSON snapshot
+  - [x] 5.11 Write edge-case tests: no `package.json`; multiple ORMs; monorepo-shaped dir (detect single package)
+  - [x] 5.12 Verify Acceptance Criterion: output includes stack/http/orm/messaging/type_hint
+  - [x] 5.13 Verify Acceptance Criterion: per-strategy OpenAPI count reported even without route 2
+  - [x] 5.14 Verify Acceptance Criterion: ExtractionProvider interface with id/detect/capabilities/optional extract
+  - [x] 5.15 Verify Acceptance Criterion: missing capability → requires_human, no failure
+  - [x] 5.16 Verify Acceptance Criterion: --json output
+  - [x] 5.17 Run Tests: `pnpm run test:unit && pnpm run test:integration && pnpm run validate`
 
 - [ ] 6.0 Implement Story S-006 - https://github.com/llipe/dev-tasks/issues/38: dt extract schema
   - [ ] 6.1 Implement `core/extract/orm/prisma.ts` — parse `schema.prisma` AST: extract models, fields (type, nullability, attributes), relations, enums


### PR DESCRIPTION
## What

Implements S-005: `dt extract detect` command and the pluggable extractor interface.

## Why

Establishes the `ExtractionProvider` interface and the Node/TS provider that all Phase 1 extraction stories will plug into. Detection is pure AST/config inspection (no LLM), reporting stack, HTTP framework, ORM, and messaging client with evidence.

## How

- Define `ExtractionProvider` interface, `Capability` type, and `DetectionResult` type in `core/extract/provider.ts`
- Implement detection orchestrator in `core/extract/detect.ts`
- Implement Node/TS provider in `core/extract/providers/node-ts.ts`
- Wire `dt extract detect` CLI command with human and `--json` output
- Test fixtures for different stack combinations
- Unit, integration, and edge-case tests

## Testing

- Unit tests: per-signal detector functions (21 tests)
- Integration tests: fixture repos to expected DetectionResult snapshots (6 tests)
- Edge-case tests: missing package.json, multiple ORMs, monorepo detection (7 tests)
- CLI integration tests (6 tests)
- `pnpm run validate` (typecheck + lint + format:check + test)

## Checklist

- [x] ExtractionProvider interface with id/detect/capabilities/optional extract methods
- [x] Capability type covers all extraction strategies
- [x] DetectionResult includes stack/http/orm/messaging/type_hint
- [x] Node/TS provider detects nestjs/express/fastify/hono, prisma/drizzle/typeorm, kafkajs
- [x] Missing capability marks artifact not-produced, records in requires_human
- [x] `--json` output supported
- [x] Per-strategy OpenAPI count reported (route2 = 0 since unimplemented)
- [x] All quality gates pass

Closes #37
